### PR TITLE
Update module name to github.com/cruise-automation/daytona

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.robot.car/cruise/daytona
+module github.com/cruise-automation/daytona
 
 require (
 	cloud.google.com/go v0.31.0


### PR DESCRIPTION
The old module name `github.robot.car/cruise/daytona` is obsolete.