### PR TITLE
Add golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+run:
+  deadline: 1m
+  modules-download-mode: vendor
+  tests: true
+
+linters:
+  enable-all: true
+  disable:
+    - lll
+
+linters-settings:
+  gocyclo:
+    min-complexity: 12
+  gofmt:
+    simplify: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package main
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.robot.car/cruise/daytona
+module github.com/cruise-automation/daytona
 
 require (
 	cloud.google.com/go v0.31.0

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package auth
@@ -57,7 +57,7 @@ func authenticate(client *api.Client, config cfg.Config, svc Authenticator) bool
 		log.Printf("could not write token to %s: %v\n", config.TokenPath, err)
 		return false
 	}
-	client.SetToken(string(vaultToken))
+	client.SetToken(vaultToken)
 	return true
 }
 
@@ -166,13 +166,17 @@ func RenewService(client *api.Client, config cfg.Config) {
 			log.Fatalln("The existing token failed renewal, exiting..")
 		}
 		ttl, err := result.TokenTTL()
+		if err != nil {
+			log.Fatalln("Failed to parse the token's ttl from JSON")
+		}
+
 		if ttl.Seconds() < float64(config.RenewalThreshold) {
 			fmt.Println("token ttl of", ttl.Seconds(), "is below threshold of", config.RenewalThreshold, ", renewing to", config.RenewalIncrement)
 			secret, err := client.Auth().Token().RenewSelf(int(config.RenewalIncrement))
 			if err != nil {
 				log.Println("Failed to renew the existing token:", err)
 			}
-			client.SetToken(string(secret.Auth.ClientToken))
+			client.SetToken(secret.Auth.ClientToken)
 			err = ioutil.WriteFile(config.TokenPath, []byte(secret.Auth.ClientToken), 0600)
 			if err != nil {
 				log.Println("Could not write token to file", config.TokenPath, err.Error())

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-const testToken = "s.iyNUhq8Ov4hIAx6snw5mB2nL"
-const testTokenLookupPayload = `
+// nolint: gosec
+const (
+	testToken              = "s.iyNUhq8Ov4hIAx6snw5mB2nL"
+	testTokenLookupPayload = `
 {
   "data": {
 	"accessor": "8609694a-cdbc-db9b-d345-e782dbb562ed",
@@ -61,8 +63,7 @@ const testTokenLookupPayload = `
   }
 }
 `
-
-const testAuthResponse = `
+	testAuthResponse = `
 {
 	"auth": {
 	  "client_token": "b.AAAAAQL_tyer_gNuQqvQYPVQgsNxjap_YW1NB2m4CDHHadQo7rF2XLFGdw-NJplAZNKbfloOvifrbpRCGdgG1taTqmC7D-a_qftN64zeL10SmNwEoDTiPzC_1aS1KExbtVftU3Sx16cBVqaynwsYRDfVnfTAffE",
@@ -83,6 +84,7 @@ const testAuthResponse = `
 	}
   }
 `
+)
 
 func TestAuthPanic(t *testing.T) {
 	var config cfg.Config

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package auth
 

--- a/pkg/auth/aws.go
+++ b/pkg/auth/aws.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package auth

--- a/pkg/auth/gcp.go
+++ b/pkg/auth/gcp.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package auth
 

--- a/pkg/auth/k8s.go
+++ b/pkg/auth/k8s.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package auth
 
@@ -50,7 +50,7 @@ func (k *K8SService) Auth(client *api.Client, config cfg.Config) (string, error)
 	return fetchVaultToken(client, config, loginData)
 }
 
-// InferK8SConfig attempts to replace default configuration parameters on K8S with ones infered from the k8s environment
+// InferK8SConfig attempts to replace default configuration parameters on K8S with ones inferred from the k8s environment
 func InferK8SConfig(config *cfg.Config) {
 	log.Println("Attempting to automatically infer some k8s configuration data")
 	if config.VaultAuthRoleName == "" {

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package auth

--- a/pkg/helpers/testhelpers/testing.go
+++ b/pkg/helpers/testhelpers/testing.go
@@ -5,7 +5,11 @@ import "github.com/hashicorp/vault/api"
 func GetTestClient(url string) (*api.Client, error) {
 	vaultConfig := api.DefaultConfig()
 	vaultConfig.Address = url
-	vaultConfig.ConfigureTLS(&api.TLSConfig{Insecure: true})
+	err := vaultConfig.ConfigureTLS(&api.TLSConfig{Insecure: true})
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := api.NewClient(vaultConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package secrets

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2019 GM Cruise LLC
+Copyright 2019 GM Cruise LLC
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package secrets


### PR DESCRIPTION
* add `.golangci.yml` file
  * now you can run linter with `golangci-lint run`
* disable `gosec` linter for one section of `auth_test.go`

**IMPORTANT: This doesn't fix all the linter issues. We'll have to fix those in followup PRs before we can enable CI.**

This is branched off #5.