### PR TITLE
Log renew errors & tag images with git tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,14 @@
 ARG GO_VERSION=1.12
 FROM golang:${GO_VERSION}-alpine AS builder
 ENV GOFLAGS -mod=vendor
-RUN apk --update add ca-certificates
+RUN apk --update add ca-certificates make
 WORKDIR /go/src/github.com/cruise-automation/daytona
 COPY . .
 RUN \
   CGO_ENABLED=0 \
   GOOS=linux \
   GOARCH=amd64 \
-  go build -a -o daytona cmd/main.go
+  make build
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-VERSION=1.0.0
+VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+VERSION_TAG=$(VERSION:v%=%) # drop the v-prefix for docker images, per convention
 PACKAGES=$(shell go list ./... | grep -v /vendor/)
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
@@ -22,8 +23,8 @@ entry:
 	@cat Makefile
 
 check:
-ifndef VERSION
-	$(error VERSION must be set for image management)
+ifndef VERSION_TAG
+	$(error VERSION_TAG must be set for image management)
 endif
 
 test:
@@ -37,12 +38,12 @@ build:
 	go build -a -o daytona cmd/daytona/main.go
 
 image: check
-	docker build -t daytona:${VERSION} .
+	docker build -t daytona:${VERSION_TAG} .
 
 push-image: check
 	@if test "$(REGISTRY)" = "" ; then \
         echo "REGISTRY but must be set in order to continue"; \
         exit 1; \
 	fi
-	docker tag daytona:${VERSION} ${REGISTRY}/daytona:${VERSION}
-	docker push ${REGISTRY}/daytona:${VERSION}
+	docker tag daytona:${VERSION_TAG} ${REGISTRY}/daytona:${VERSION_TAG}
+	docker push ${REGISTRY}/daytona:${VERSION_TAG}


### PR DESCRIPTION
Two changes, I can split them if you'd like.

1. I see the container as a sidecar restarting, and while I think it's because of Vault timeout, I'd like to see the error.
2. Tags the docker images using the latest docker tag. Appends the latest commit sha if not on a tag. So this branch is:
```
$ make image                                
docker build -t daytona:1.0.1-11-gfbb7f80  .
```
Future releases you can run `git tag -s v1.0.2` to tag and then the image tag will be up-to-date.