### PR TITLE
Change in the path-matching functionality, along with corresponding README update.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ lint:
 	go vet ${PACKAGES}
 	gofmt -d -l ${GOFILES}
 
+coverage:
+	go test -v -cover -coverprofile=coverage.out ${PACKAGES}
+	go tool cover -html=coverage.out
+
 build:
 	go build -ldflags="-s -w" -a -o daytona cmd/daytona/main.go
 	@type -P upx && upx daytona || echo "[INFO] No upx installed, not compressing."

--- a/README.md
+++ b/README.md
@@ -43,7 +43,17 @@ The following authentication methods are supported:
 
  Any unique value can be appended to `VAULT_SECRET_` in order to provide the ability to supply multiple secret paths. e.g. `VAULT_SECRETS_APPLICATION=secret/path/to/my/application/directory`, `VAULT_SECRETS_COMMON=secret/path/common`, `VAULT_SECRET_1=secret/path/to/individual/secret`.
 
-If a secret in Vault has a corresponding environment variable pointed at a file location prefixed with `DAYTONA_SECRET_DESTINATION` then the secret is written to that location instead of the default destination. For example, if `VAULT_SECRET_API_KEY=secret/path/to/API_KEY` and `DAYTONA_SECRET_DESTINATION_API_KEY='/etc/api.conf'` are defined then the key is written to /etc/api.conf instead of the default location. Other keys are written at the normal location as defined by their `VAULT_SECRET` value.
+### Secret fetching in depth
+
+- `VAULT_SECRETS_`: One or more _locations_ in vault can be specified using this as an envvar prefix, indicating a path for `daytona` to iterate over. If `VAULT_SECRETS_APPLICATION='secret/path/to/my/application/directory'` is provided, with the secrets `api_key`, `db_key`, and `password` under it, these secrets will be discovered and available for use via one of these output methods:
+  + `DAYTONA_SECRET_DESTINATION_`: If a discovered secret name is prefixed with `DAYTONA_SECRET_DESTINATION_`, the secret will be written to the location provided. In the example above, if `DAYTONA_SECRET_DESTINATION_db_key` is specified, the `db_key` secret will b e written to the location provided. This must be a file that is writable by `daytona`.
+  + `SECRET_PATH`: When this envvar/CLI flag is provided, the secrets will be written in a JSON blob at the location provided.
+  + `SECRET_ENV`: When this is used in conjunction with the `-entrypoint` flag, these secrets will be populated as the envvars `api_key`, `db_key`, and `password`  with their corresponding values.
+
+- `VAULT_SECRET_`: One or more _secret paths_ in vault can be specified using this as an envvar prefix, indicating a single secret for `daytona` to retrieve. If `VAULT_SECRET_ROOT_PW='secret/path/to/my/application/root_password'` is provided, this secret will be retrieved and available for use via one of these output methods:
+  + `DAYTONA_SECRET_DESTINATION_`: If used with `VAULT_SECRET_`, and the secret name is prefixed with `DAYTONA_SECRET_DESTINATION_`, the secret will be written to the location provided. In the example above, if `DAYTONA_SECRET_DESTINATION_ROOT_PW` is specified, the `root_password` secret will be written to the location provided. This must be a file that is writable by `daytona`. *Note*: this is slightly different functionality than `VAULT_SECRETS_`; the pairing of source path in vault and destination path locally are determined by the suffix used in the `VAULT_SECRET_` & `DAYTONA_SECRET_DESTINATION_` envvars.
+  + `SECRET_PATH`: When this envvar/CLI flag is provided, the secret will be written in a JSON blob at the location provided. Note that if `SECRET_PATH` is used as well as a `DAYTONA_SECRET_DESTINATION_` envvar that matches the `VAULT_SECRET_`, the secret value will be written in _both_ locations.
+  + `SECRET_ENV`: When this is used in conjunction with the `-entrypoint` flag, this secrets will be populated as the envvar `ROOT_PW`.
 
 #### Outputs
 

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -76,9 +76,8 @@ func TestSecretPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	assert.Equal(t, "standard", secrets["applicationA"])
-	assert.Equal(t, "nonstandard", secrets["applicationA_password"])
+	assert.Equal(t, "standard", secrets["APPLICATIONA"])
+	assert.Equal(t, "nonstandard", secrets["APPLICATIONA_password"])
 }
 
 func TestSecretDirectPath(t *testing.T) {
@@ -111,9 +110,9 @@ func TestSecretDirectPath(t *testing.T) {
 	defer os.Remove(file.Name())
 
 	os.Setenv("VAULT_SECRET_APPLICATIONA", "secret/applicationa")
-	os.Setenv("DAYTONA_SECRET_DESTINATION_applicationa", file.Name())
+	os.Setenv("DAYTONA_SECRET_DESTINATION_APPLICATIONA", file.Name())
 	defer os.Unsetenv("VAULT_SECRET_APPLICATIONA")
-	defer os.Unsetenv("DAYTONA_SECRET_DESTINATION_applicationa")
+	defer os.Unsetenv("DAYTONA_SECRET_DESTINATION_APPLICATIONA")
 	SecretFetcher(client, config)
 
 	data, err := ioutil.ReadFile(file.Name())
@@ -123,7 +122,78 @@ func TestSecretDirectPath(t *testing.T) {
 	assert.Equal(t, "standard", string(data))
 }
 
-func TestSecretAWalk(t *testing.T) {
+func TestSecretDirectPathArbitraryIdentifiers(t *testing.T) {
+	var config cfg.Config
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "nba_jam") {
+			fmt.Fprintln(w, `
+			{
+				"auth": null,
+				"data": {
+				  "value": "from downtooooownnnnnnnn!"
+				},
+				"lease_duration": 3600,
+				"lease_id": "",
+				"renewable": false
+			  }
+			`)
+		}
+		if strings.HasSuffix(r.URL.Path, "nba_jam_on_fire") {
+			fmt.Fprintln(w, `
+			{
+				"auth": null,
+				"data": {
+				  "value": "boomshakalaka!"
+				},
+				"lease_duration": 3600,
+				"lease_id": "",
+				"renewable": false
+			  }
+			`)
+		}
+	}))
+	defer ts.Close()
+
+	client, err := testhelpers.GetTestClient(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.SecretPayloadPath = ""
+	file_lower, err := ioutil.TempFile(os.TempDir(), "secret-direct-path-arbitrary-lower-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file_upper, err := ioutil.TempFile(os.TempDir(), "secret-direct-path-arbitrary-upper-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file_lower.Name())
+	defer os.Remove(file_upper.Name())
+
+	os.Setenv("VAULT_SECRET_shut_up_and_jam", "secret/nba_jam")
+	os.Setenv("DAYTONA_SECRET_DESTINATION_shut_up_and_jam", file_lower.Name())
+	os.Setenv("VAULT_SECRET_shut_up_and_JAM", "secret/nba_jam_on_fire")
+	os.Setenv("DAYTONA_SECRET_DESTINATION_shut_up_and_JAM", file_upper.Name())
+	defer os.Unsetenv("VAULT_SECRET_shut_up_and_jam")
+	defer os.Unsetenv("DAYTONA_SECRET_DESTINATION_shut_up_and_jam")
+	defer os.Unsetenv("VAULT_SECRET_shut_up_and_JAM")
+	defer os.Unsetenv("DAYTONA_SECRET_DESTINATION_shut_up_and_JAM")
+	SecretFetcher(client, config)
+
+	data_lower, err := ioutil.ReadFile(file_lower.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data_upper, err := ioutil.ReadFile(file_upper.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "from downtooooownnnnnnnn!", string(data_lower))
+	assert.Equal(t, "boomshakalaka!", string(data_upper))
+}
+
+func TestSecretWalkSingleOutput(t *testing.T) {
 	var config cfg.Config
 
 	ts := httptest.NewTLSServer(
@@ -177,4 +247,76 @@ func TestSecretAWalk(t *testing.T) {
 	assert.Equal(t, "aaaa", secrets["credentials_api_a"])
 	assert.Equal(t, "bbbb", secrets["credentials_api_b"])
 	assert.Equal(t, "password", secrets["other"])
+}
+
+func TestSecretWalkMultipleOutput(t *testing.T) {
+	var config cfg.Config
+
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				q := r.URL.Query()
+				list := q.Get("list")
+				if list == "true" {
+					fmt.Fprintln(w, `{"data": {"keys": ["credentials", "keys", "other_a", "other_A"]}}`)
+				} else {
+					if strings.HasSuffix(r.URL.Path, "keys") {
+						fmt.Fprintln(w, `{"data": {"api_key": "xx"}}`)
+					}
+					if strings.HasSuffix(r.URL.Path, "credentials") {
+						fmt.Fprintln(w, `{"data": {"api_a": "aaaa", "api_b":"bbbb"}}`)
+					}
+					if strings.HasSuffix(r.URL.Path, "other_a") {
+						fmt.Fprintln(w, `{"data": {"value": "password"}}`)
+					}
+					if strings.HasSuffix(r.URL.Path, "other_A") {
+						fmt.Fprintln(w, `{"data": {"value": "upper_case_secret_path"}}`)
+					}
+				}
+			}))
+	defer ts.Close()
+
+	client, err := testhelpers.GetTestClient(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := ioutil.TempFile(os.TempDir(), "secret-walk-output-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest_file, err := ioutil.TempFile(os.TempDir(), "secret-walk-dest-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+	defer os.Remove(dest_file.Name())
+
+	os.Setenv("VAULT_SECRETS_COMMON", "secret/path/common")
+	os.Setenv("DAYTONA_SECRET_DESTINATION_other_A", dest_file.Name())
+	defer os.Unsetenv("VAULT_SECRETS_COMMON")
+	defer os.Unsetenv("DAYTONA_SECRET_DESTINATION_other_A")
+	config.SecretPayloadPath = file.Name()
+	SecretFetcher(client, config)
+
+	secrets := make(map[string]string)
+	data, err := ioutil.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal(data, &secrets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest_data, err := ioutil.ReadFile(dest_file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "xx", secrets["keys_api_key"])
+	assert.Equal(t, "aaaa", secrets["credentials_api_a"])
+	assert.Equal(t, "bbbb", secrets["credentials_api_b"])
+	assert.Equal(t, "password", secrets["other_a"])
+	assert.Equal(t, "upper_case_secret_path", secrets["other_A"])
+	assert.Equal(t, "upper_case_secret_path", string(dest_data))
 }


### PR DESCRIPTION
This includes the following changes to make working with Daytona behavior a bit more intuitive:

- When using `VAULT_SECRETS_` with `DAYTONA_SECRET_DESTINATION_`, the secret name discovered via a secrets walk in Vault is used as the suffix to `DAYTONA_SECRET_DESTINATION_` to specify the output location. (This is the current behavior, and unchanged, but with tests now, and an updated/reworded README)
- When using `VAULT_SECRET_` with `DAYTONA_SECRET_DESTINATION_` to specify a direct secret path, the suffix name in these two envvars is used as the key to identify and pair them, instead of the secret name discovered in Vault. This allows for more intuitive behavior, and may simplify some workflows, especially those that have a lowercase secret key name in Vault, but require the use of (or disuse of) certain characters (`.` in envvars come to mind).