### PR TITLE
Single value retrieval

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -217,7 +217,7 @@ func (sd *SecretDefinition) addSecrets(client *api.Client, secretResult *SecretR
 		v, ok := secretData[singleValueKey]
 		if ok {
 			sd.secrets[singleValueKey] = v.(string)
-			log.Printf("Found an explicit vault value key %s, will only read value %s", secretValueKeyPrefix+sd.secretID, singleValueKey)
+			log.Printf("Found an explicit vault value key %s, will only read value %s\n", secretValueKeyPrefix+sd.secretID, singleValueKey)
 			return nil
 		}
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -33,6 +33,7 @@ import (
 const (
 	defaultKeyName           = "value"
 	secretDestinationPrefix  = "DAYTONA_SECRET_DESTINATION_"
+	secretValueKeyPrefix     = "VAULT_VALUE_KEY_"
 	secretStoragePathPrefix  = "VAULT_SECRET_"
 	secretsStoragePathPrefix = "VAULT_SECRETS_"
 )
@@ -210,6 +211,16 @@ func (sd *SecretDefinition) addSecrets(client *api.Client, secretResult *SecretR
 
 	// Return last error encountered during processing, if any
 	var lastErr error
+
+	singleValueKey := os.Getenv(secretValueKeyPrefix + sd.secretID)
+	if singleValueKey != "" && !sd.plural {
+		v, ok := secretData[singleValueKey]
+		if ok {
+			sd.secrets[singleValueKey] = v.(string)
+			log.Printf("Found an explicit vault value key %s, will only read value %s", secretValueKeyPrefix+sd.secretID, singleValueKey)
+			return nil
+		}
+	}
 
 	for k, v := range secretData {
 		switch k {


### PR DESCRIPTION
Introduce a Value Key prefix that can be used for retrieving a single value from a singular secret definition

Instead of attempting to retrieve every value within the vault path, only the value provided by `VAULT_VALUE_KEY_<secretID-SUFFIX>` will be returned to the ouput.

```
VAULT_SECRET_SINGLE=gcp/key/my-key-roleset
DAYTONA_SECRET_DESTINATION_UPPER=./output
VAULT_VALUE_KEY_UPPER=private_key_data
```