### PR TITLE
Makefile: no need to re-build entire go stdlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ lint:
 	gofmt -d -l ${GOFILES}
 
 build:
-	CGO_ENABLED=0 go build ${GO_LDFLAGS} -a -o daytona cmd/daytona/main.go
+	CGO_ENABLED=0 go build ${GO_LDFLAGS} -o daytona cmd/daytona/main.go
 	@type -P upx && upx daytona || echo "[INFO] No upx installed, not compressing."
 
 image: check


### PR DESCRIPTION
Using the `-a` flag on build rebuilds the entire standard library for
daytona, which slows down the build immensely. There are plenty of
others ways to force a build to go through if there are problems, so 
we can remove this.