### PR TITLE
Fix docker build / make image: adding git to Dockerfile builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ARG GO_VERSION=1.13
 FROM golang:${GO_VERSION}-alpine AS builder
 ENV GOFLAGS -mod=vendor
-RUN apk --update add ca-certificates make upx
+RUN apk --update add ca-certificates make upx git
 WORKDIR /go/src/github.com/cruise-automation/daytona
 COPY . .
 RUN \


### PR DESCRIPTION
Today since git is not installed while building the docker image the version is not set, see below:
```
 ---> Running in e12300c7f495
CGO_ENABLED=0 go build -ldflags '-s -w -X main.version=' -o daytona cmd/daytona/main.go
make: git: No such file or directory
```

Adding git will allow to retrieve the version, and generate the image like:
```
 ---> Running in f6d8e64950e9
CGO_ENABLED=0 go build -ldflags '-s -w -X main.version=v1.1.2-1-g50f1ad1' -o daytona cmd/daytona/main.go
```