### PR TITLE
Send errors and fatal errors to stderr, everything else should be sent to stdout

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -16,6 +16,36 @@ type Config struct {
 	LevelFieldName string
 }
 
+type ErrorFilteredWriter struct {
+	w zerolog.LevelWriter
+}
+
+func (w *ErrorFilteredWriter) Write(p []byte) (n int, err error) {
+	return w.w.Write(p)
+}
+
+func (w *ErrorFilteredWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
+	if level >= zerolog.ErrorLevel {
+		return w.w.WriteLevel(level, p)
+	}
+	return len(p), nil
+}
+
+type NonErrorFilteredWriter struct {
+	w zerolog.LevelWriter
+}
+
+func (w *NonErrorFilteredWriter) Write(p []byte) (n int, err error) {
+	return w.w.Write(p)
+}
+
+func (w *NonErrorFilteredWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
+	if level < zerolog.ErrorLevel {
+		return w.w.WriteLevel(level, p)
+	}
+	return len(p), nil
+}
+
 // Setup the logging level, level field name and output (JSON or console).
 func Setup(cfg Config) {
 	level, err := zerolog.ParseLevel(cfg.Level)
@@ -26,7 +56,12 @@ func Setup(cfg Config) {
 	zerolog.SetGlobalLevel(level)
 	zerolog.LevelFieldName = cfg.LevelFieldName
 
-	var writer io.Writer = os.Stderr
+	// Write errors and fatal errors to Stderr
+	errWriter := &ErrorFilteredWriter{zerolog.MultiLevelWriter(os.Stderr)}
+	// Write debug, informational, and warnings to Stdout
+	nonErrWriter := &NonErrorFilteredWriter{zerolog.MultiLevelWriter(os.Stdout)}
+
+	var writer io.Writer = zerolog.MultiLevelWriter(errWriter, nonErrWriter)
 
 	if !cfg.Structured {
 		cslWriter := zerolog.NewConsoleWriter()


### PR DESCRIPTION
Previously all log messages from Daytona were sent to stderr which makes it difficult to write monitoring and alerting for Daytona failures (such as with [log based metrics](https://cloud.google.com/logging/docs/logs-based-metrics/charts-and-alerts#specifying_logs-based_metrics)).  Now all errors and fatal errors are sent to stderr.  Debug messages, informational messages, and warnings are sent to stdout.

See this issue for the inspiration of using FilteredWriters https://github.com/rs/zerolog/issues/150