### PR TITLE
Attempt to locate destination definitions that don't have a matching …

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -156,11 +156,11 @@ func SecretFetcher(client *api.Client, config cfg.Config) {
 	// 		db_password
 	// 		api_key
 	// it has keys like:
-	// and configurated destinations like
+	// and configured destinations such as
 	// 	DAYTONA_SECRET_DESTINATION_db_password
 	//	DAYTONA_SECRET_DESTINATION_api_key
 	// or VAULT_SECRET_API_KEY = secret/yourapplication/api_key
-	// and configurated destinations like
+	// and configured destinations such as
 	//	DAYTONA_SECRET_DESTINATION_api_key
 	for destKey := range destinations {
 		for j := range defs {

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -132,6 +132,8 @@ func SecretFetcher(client *api.Client, config cfg.Config) {
 		defs = append(defs, def)
 	}
 
+	secretPayloadPathOutput := make(map[string]string)
+
 	// output the secret definitions
 	for _, def := range defs {
 		if config.SecretEnv {
@@ -143,10 +145,17 @@ func SecretFetcher(client *api.Client, config cfg.Config) {
 		}
 
 		if config.SecretPayloadPath != "" {
-			err := writeJSONSecrets(def.secrets, config.SecretPayloadPath)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Could not write JSON secrets")
+			for k, v := range def.secrets {
+				secretPayloadPathOutput[k] = v
 			}
+		}
+	}
+
+	if config.SecretPayloadPath != "" {
+		log.Warn().Msg("secret path output functionality is planned for deprecation in version 2.0.0")
+		err := writeJSONSecrets(secretPayloadPathOutput, config.SecretPayloadPath)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Could not write JSON secrets")
 		}
 	}
 
@@ -236,7 +245,7 @@ func valueConverter(value interface{}) (string, error) {
 }
 
 func writeFile(path string, data []byte) error {
-	err := ioutil.WriteFile(path, data, 0400)
+	err := ioutil.WriteFile(path, data, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…source definition. This should increase the likelihood of supporting legacy configurations.

This PR is an attempt to add best-effort backwards compatibility to pre-1.1.0 versions, specifically around locating unmatched destinations. Pre 1.1.0 required the `DAYTONA_SECRET_DESTINATION_` suffix to match the key name, where 1.1.0 dropped this rather inflexible dependency in favor of abstract suffixes. (see #33 for details)

**e.g.**:

A pre-1.1.0 version would have the secret definition `VAULT_SECRETS_API_KEY=secret/yourapplication` with keys like:

  - db_password
  - api_key

and with the following configured destinations:
  - `DAYTONA_SECRET_DESTINATION_db_password=/secrets/dbpassword`
  - `DAYTONA_SECRET_DESTINATION_api_key=/secrets/apikey`

or `VAULT_SECRET_API = secret/yourapplication/api_key` and a configured destination: `DAYTONA_SECRET_DESTINATION_api_key=/secrets/key`


This is achieved by introducing a `destinations` map, that is referenced against the compiled secret definitions. If a match is found, the secret output as configured.

----

This also fixes #43 where if `VAULT_SECRET_PATH` is defined, only the last `VAULT_SECRET(S)_` definition is written to file. In this PR, all secret definitions are aggregated into a single `map`, marshaled into JSON and written to the `VAULT_SECRET_PATH`. An exception is, that if someone had duplicate key names in another path, the last read secret would would be overwritten.

```
VAULT_SECRET_WHATEVER=secret/whatever/password
VAULT_SECRET_THING=secret/thing/api_key
```

output:

```
{
  "password": "XXXXXX",
  "api_key": "YYYYY"
}
```

--

exception case:

```
VAULT_SECRET_PASSWORD1=secret/whatever/password
VAULT_SECRET_PASSWORD2=secret/thing/password
```
output:
```
{
  "password": "XXXXXX"
}
```

