### PR TITLE
Fix panic when vault return a map

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -234,12 +234,16 @@ func (sd *SecretDefinition) addSecrets(client *api.Client, secretResult *SecretR
 	}
 
 	for k, v := range secretData {
+		var err error
 		secretValue, ok := v.(string)
 		if !ok {
-			value, lastErr = json.Marshal(v)
+			value, err = json.Marshal(v)
+			if err != nil {
+				lastErr = err
+			}
 			secretValue = string(value)
 		}
-		if lastErr == nil {
+		if err == nil {
 			switch k {
 			case defaultKeyName:
 				sd.secrets[keyName] = secretValue

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -219,7 +219,7 @@ func (sd *SecretDefinition) addSecrets(client *api.Client, secretResult *SecretR
 	if singleValueKey != "" && !sd.plural {
 		v, ok := secretData[singleValueKey]
 		if ok {
-			sd.secrets[singleValueKey] = v.(string)
+			sd.secrets[singleValueKey] = fmt.Sprintf("%v", v)
 			log.Info().Str("key", secretValueKeyPrefix+sd.secretID).Str("value", singleValueKey).Msg("Found an explicit vault value key, will only read value")
 			return nil
 		}
@@ -228,10 +228,10 @@ func (sd *SecretDefinition) addSecrets(client *api.Client, secretResult *SecretR
 	for k, v := range secretData {
 		switch k {
 		case defaultKeyName:
-			sd.secrets[keyName] = v.(string)
+			sd.secrets[keyName] = fmt.Sprintf("%v", v)
 		default:
 			expandedKeyName := fmt.Sprintf("%s_%s", keyName, k)
-			sd.secrets[expandedKeyName] = v.(string)
+			sd.secrets[expandedKeyName] = fmt.Sprintf("%v", v)
 		}
 	}
 	return lastErr

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -324,3 +324,22 @@ func TestSecretAWalk(t *testing.T) {
 	assert.Equal(t, `{"bar":"baz"}`, destSecrets["credentials_api_foo"])
 	assert.Equal(t, "password", destSecrets["other"])
 }
+
+func TestValueConverter(t *testing.T) {
+	const str = "A string"
+	res, err := valueConverter(str)
+	assert.Equal(t, str, res)
+	assert.NoError(t, err)
+
+	res, err = valueConverter(map[string]interface{}{"foo": "bar"})
+	assert.Equal(t, `{"foo":"bar"}`, res)
+	assert.NoError(t, err)
+
+	res, err = valueConverter(map[string]interface{}{"foo": make(chan struct{})})
+	assert.Equal(t, "", res)
+	assert.Error(t, err)
+
+	res, err = valueConverter([]string{"baz"})
+	assert.Equal(t, "", res)
+	assert.Error(t, err)
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -315,12 +315,12 @@ func TestSecretAWalk(t *testing.T) {
 	assert.Equal(t, "xx", secrets["keys_api_key"])
 	assert.Equal(t, "aaaa", secrets["credentials_api_a"])
 	assert.Equal(t, "bbbb", secrets["credentials_api_b"])
-	assert.Equal(t, "map[bar:baz]", secrets["credentials_api_foo"])
+	assert.Equal(t, `{"bar":"baz"}`, secrets["credentials_api_foo"])
 	assert.Equal(t, "password", secrets["other"])
 
 	assert.Equal(t, "xx", destSecrets["keys_api_key"])
 	assert.Equal(t, "aaaa", destSecrets["credentials_api_a"])
 	assert.Equal(t, "bbbb", destSecrets["credentials_api_b"])
-	assert.Equal(t, "map[bar:baz]", destSecrets["credentials_api_foo"])
+	assert.Equal(t, `{"bar":"baz"}`, destSecrets["credentials_api_foo"])
 	assert.Equal(t, "password", destSecrets["other"])
 }

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -254,7 +254,7 @@ func TestSecretAWalk(t *testing.T) {
 						fmt.Fprintln(w, `{"data": {"api_key": "xx"}}`)
 					}
 					if strings.HasSuffix(r.URL.Path, "credentials") {
-						fmt.Fprintln(w, `{"data": {"api_a": "aaaa", "api_b":"bbbb"}}`)
+						fmt.Fprintln(w, `{"data": {"api_a": "aaaa", "api_b":"bbbb", "api_foo": {"bar": "baz"}}}`)
 					}
 					if strings.HasSuffix(r.URL.Path, "other") {
 						fmt.Fprintln(w, `{"data": {"value": "password"}}`)
@@ -315,10 +315,12 @@ func TestSecretAWalk(t *testing.T) {
 	assert.Equal(t, "xx", secrets["keys_api_key"])
 	assert.Equal(t, "aaaa", secrets["credentials_api_a"])
 	assert.Equal(t, "bbbb", secrets["credentials_api_b"])
+	assert.Equal(t, "map[bar:baz]", secrets["credentials_api_foo"])
 	assert.Equal(t, "password", secrets["other"])
 
 	assert.Equal(t, "xx", destSecrets["keys_api_key"])
 	assert.Equal(t, "aaaa", destSecrets["credentials_api_a"])
 	assert.Equal(t, "bbbb", destSecrets["credentials_api_b"])
+	assert.Equal(t, "map[bar:baz]", destSecrets["credentials_api_foo"])
 	assert.Equal(t, "password", destSecrets["other"])
 }


### PR DESCRIPTION
If vault api return an map we are currently panicking, see below:
```
panic: interface conversion: interface {} is map[string]interface {}, not string

goroutine 1 [running]:
github.com/cruise-automation/daytona/pkg/secrets.(*SecretDefinition).addSecrets(0xc0001c7730, 0xc00029a770, 0xc0000bc090, 0x0, 0x4)
	/Users/myuser/daytona/pkg/secrets/secrets.go:235 +0x9c8
github.com/cruise-automation/daytona/pkg/secrets.SecretFetcher(0xc00029a770, 0x0, 0x0, 0x7ffeefbff6dd, 0x21, 0x177f0fc, 0x33, 0x0, 0x1763bb4, 0xa, ...)
	/Users/myuser/daytona/pkg/secrets/secrets.go:128 +0x62a
main.main()
	/Users/myuser/daytona/cmd/daytona/main.go:202 +0x318
```

This fix will avoid and panic and replicate `vault read` behavior.
```
$ vault read -field=foo secret/foo
map[bar:baz]
```