### PR TITLE
Rename LOG_LEVEL so as to not conflict with downstream applications.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-cmd/daytona/daytona
-daytona
-coverage.out
+/cmd/daytona/daytona
+/daytona
+/coverage.out

--- a/README.md
+++ b/README.md
@@ -488,11 +488,11 @@ Usage of ./daytona:
   -k8s-token-path string
       kubernetes service account jtw token path (env: K8S_TOKEN_PATH) (default "/var/run/secrets/kubernetes.io/serviceaccount/token")
   -log-level string
-      defines log levels ('trace', 'debug', 'info', 'warn', 'error', 'fatal', 'panic', '') (env: LOG_LEVEL) (default "debug")
+      defines log levels ('trace', 'debug', 'info', 'warn', 'error', 'fatal', 'panic', '') (env: DAYTONA_LOG_LEVEL) (default "debug")
   -log-level-field-name string
-      the field name used for the level field (env: LOG_LEVEL_FIELD_NAME) (default "level")
+      the field name used for the level field (env: DAYTONA_LOG_LEVEL_FIELD_NAME) (default "level")
   -log-structured
-      if set, log output will be JSON else writes human-friendly format (env: LOG_STRUCTURED) (default true)
+      if set, log output will be JSON else writes human-friendly format (env: DAYTONA_LOG_STRUCTURED) (default true)
   -max-auth-duration int
       the value, in seconds, for which DAYTONA should attempt to renew a token before exiting (env: MAX_AUTH_DURATION) (default 300)
   -pki-cert string

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -138,10 +138,10 @@ func init() {
 		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("PKI_USE_CA_CHAIN", "false"))
 		return err == nil && b
 	}(), "if set, retrieve the CA chain and include it in the certificate file output (env: PKI_USE_CA_CHAIN)")
-	flag.StringVar(&config.Log.Level, "log-level", cfg.BuildDefaultConfigItem(logging.EnvLevel, "debug"), "defines log levels ('trace', 'debug', 'info', 'warn', 'error', 'fatal', 'panic', '') (env: "+logging.EnvLevel+")")
-	flag.StringVar(&config.Log.LevelFieldName, "log-level-field-name", cfg.BuildDefaultConfigItem("LOG_LEVEL_FIELD_NAME", zerolog.LevelFieldName), " the field name used for the level field (env: LOG_LEVEL_FIELD_NAME)")
+	flag.StringVar(&config.Log.Level, "log-level", cfg.BuildDefaultConfigItem("DAYTONA_LOG_LEVEL", "debug"), "defines log levels ('trace', 'debug', 'info', 'warn', 'error', 'fatal', 'panic', '') (env: DAYTONA_LOG_LEVEL)")
+	flag.StringVar(&config.Log.LevelFieldName, "log-level-field-name", cfg.BuildDefaultConfigItem("DAYTONA_LOG_LEVEL_FIELD_NAME", zerolog.LevelFieldName), " the field name used for the level field (env: DAYTONA_LOG_LEVEL_FIELD_NAME)")
 	flag.BoolVar(&config.Log.Structured, "log-structured", func() bool {
-		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("LOG_STRUCTURED", "true"))
+		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("DAYTONA_LOG_STRUCTURED", "true"))
 		return err == nil && b
 	}(), "if set, log output will be JSON else writes human-friendly format (env: LOG_STRUCTURED)")
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -8,8 +8,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const EnvLevel = "LOG_LEVEL"
-
 type Config struct {
 	Structured     bool
 	Level          string


### PR DESCRIPTION
This PR renames `LOG_LEVEL`, `LOG_LEVEL_FIELD_NAME`, and `LOG_STRUCTURED` to all be prefixed with `DAYTONA_`, so as to not conflict with applications executed by Daytona when used as an `ENTRYPOINT` in a containerized environment. This also updates README.md, and has some minor fixes to `.gitignore`.