### PR TITLE
Parallel reader improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifndef VERSION_TAG
 endif
 
 test:
-	go test -cover -count=1 -v ${PACKAGES}
+	go test -race -cover -count=1 -v ${PACKAGES}
 
 coverage:
 	go test -cover -count=1 -coverprofile=coverage.out -v ${PACKAGES}

--- a/pkg/secrets/reader_test.go
+++ b/pkg/secrets/reader_test.go
@@ -18,135 +18,84 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"path"
 	"testing"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 )
 
-type TestParameters struct {
-	NumKeys    int
-	NumWorkers int
-	Err        error
-}
+func TestParallelReaderBasic(t *testing.T) {
+	apex := "secret/thing"
 
-func TestParallelReader(t *testing.T) {
-	tests := []TestParameters{
-		TestParameters{
-			NumKeys:    0,
-			NumWorkers: 1,
-			Err:        nil,
-		},
-		TestParameters{
-			NumKeys:    1,
-			NumWorkers: 1,
-			Err:        nil,
-		},
-		TestParameters{
-			NumKeys:    5,
-			NumWorkers: 1,
-			Err:        nil,
-		},
-		TestParameters{
-			NumKeys:    2,
-			NumWorkers: 2,
-			Err:        nil,
-		},
-		TestParameters{
-			NumKeys:    1,
-			NumWorkers: 2,
-			Err:        nil,
-		},
-		TestParameters{
-			NumKeys:    5,
-			NumWorkers: 5,
-			Err:        nil,
-		},
-		TestParameters{
-			NumKeys:    0,
-			NumWorkers: 5,
-			Err:        nil,
-		},
-		TestParameters{
-			NumKeys:    5,
-			NumWorkers: 5,
-			Err:        fmt.Errorf("mock error"),
-		},
+	keys := []string{"one", "two"}
+	paths := make([]string, len(keys))
+
+	for i := range keys {
+		paths[i] = path.Join(apex, keys[i])
 	}
-
-	for _, testParameters := range tests {
-		testParallelReadIteration(t, testParameters)
-	}
-}
-
-func testParallelReadIteration(t *testing.T, testParameters TestParameters) {
-	expectedSecretResults := getExpectedSecretResults(testParameters)
 
 	ctx := context.Background()
-	logicalClient := &MockLogicalClient{
-		FakeErr: testParameters.Err,
-	}
 
-	parallelReader := NewParallelReader(ctx, logicalClient, testParameters.NumWorkers)
+	logicalClient := &MockLogicalClient{
+		FakeErr: nil,
+	}
+	parallelReader := NewParallelReader(ctx, logicalClient, 3)
 	defer parallelReader.Close()
 
-	for i := 0; i < testParameters.NumKeys; i++ {
-		parallelReader.AsyncRequestKeyPath(fmt.Sprintf("fake/path/key%d", i))
+	def := &SecretDefinition{
+		envkey:     "VAULT_SECRET_MEET",
+		secretApex: apex,
+		paths:      paths,
+		secrets:    make(map[string]string),
 	}
 
-	secretResults := make(map[string]*SecretResult)
-	for i := 0; i < testParameters.NumKeys; i++ {
-		secretResult := parallelReader.ReadSecretResult()
-		secretResults[secretResult.KeyPath] = secretResult
+	err := parallelReader.ReadPaths(def)
+
+	if err != nil {
+		t.Fatal(err)
 	}
+	assert.Equal(t, 2, len(def.secrets))
 
-	assert.Equal(t, len(secretResults), testParameters.NumKeys)
-	for expectedKeyPath, expectedSecretResult := range expectedSecretResults {
-		secretResult, exists := secretResults[expectedKeyPath]
-		assert.Equal(t, true, exists)
-
-		assert.Equal(t, expectedSecretResult.KeyPath, secretResult.KeyPath)
-		assert.Equal(t, expectedSecretResult.Err, secretResult.Err)
-
-		assert.Equal(t, expectedSecretResult.Secret.RequestID, secretResult.Secret.RequestID)
-		assert.Equal(t, expectedSecretResult.Secret.LeaseID, secretResult.Secret.LeaseID)
-		assert.Equal(t, expectedSecretResult.Secret.LeaseDuration, secretResult.Secret.LeaseDuration)
-		assert.Equal(t, expectedSecretResult.Secret.Renewable, secretResult.Secret.Renewable)
-		assert.Equal(t, expectedSecretResult.Secret.Data, secretResult.Secret.Data)
-		assert.Equal(t, expectedSecretResult.Secret.Warnings, secretResult.Secret.Warnings)
+	for i := range keys {
+		v, ok := def.secrets[keys[i]]
+		if !ok {
+			t.Error("expected key to be present in secrets")
+		}
+		assert.Equal(t, "xxxx", v)
 	}
 }
 
-func getExpectedSecretResults(testParameters TestParameters) map[string]*SecretResult {
-	secretResults := make(map[string]*SecretResult)
-	for i := 0; i < testParameters.NumKeys; i++ {
-		keyPath := fmt.Sprintf("fake/path/key%d", i)
+func TestParallelReaderError(t *testing.T) {
+	apex := "secret/thing"
 
-		secret := &api.Secret{
-			RequestID: keyPath,
+	keys := []string{"one"}
+	paths := make([]string, len(keys))
+	errorMsg := "nope nope nope"
 
-			LeaseID:       "abc",
-			LeaseDuration: 600,
-			Renewable:     true,
-
-			Data: map[string]interface{}{
-				"key": keyPath,
-			},
-
-			Warnings: []string{},
-		}
-
-		secretResult := &SecretResult{
-			KeyPath: keyPath,
-			Secret:  secret,
-			Err:     testParameters.Err,
-		}
-
-		secretResults[secretResult.KeyPath] = secretResult
+	for i := range keys {
+		paths[i] = path.Join(apex, keys[i])
 	}
 
-	return secretResults
+	logicalClient := &MockLogicalClient{
+		FakeErr: errors.New("nope nope nope"),
+	}
+	ctx := context.Background()
+
+	parallelReader := NewParallelReader(ctx, logicalClient, 3)
+	defer parallelReader.Close()
+
+	def := &SecretDefinition{
+		envkey:     "VAULT_SECRET_MEET",
+		secretApex: apex,
+		paths:      paths,
+		secrets:    make(map[string]string),
+	}
+
+	err := parallelReader.ReadPaths(def)
+	assert.EqualError(t, err, fmt.Sprintf("failed to retrieve secret path %s: %s", paths[0], errorMsg))
 }
 
 // MockLogicalClient is an implementation that satisfies LogicalClient interface
@@ -164,7 +113,7 @@ func (m *MockLogicalClient) Read(path string) (*api.Secret, error) {
 		Renewable:     true,
 
 		Data: map[string]interface{}{
-			"key": path,
+			"value": "xxxx",
 		},
 
 		Warnings: []string{},

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -627,3 +627,88 @@ func TestExcessiveSecretPathIteration(t *testing.T) {
 
 	assert.Equal(t, 1000, len(secrets))
 }
+
+func TestBulkSecretWorker(t *testing.T) {
+	var config cfg.Config
+
+	var keys [1800]string
+
+	for i := 0; i < 1800; i++ {
+		keys[i] = fmt.Sprintf("text%v", i)
+	}
+
+	var x = struct {
+		Data map[string]interface{} `json:"data"`
+	}{
+		Data: map[string]interface{}{
+			"keys": keys,
+		},
+	}
+
+	b, err := json.Marshal(x)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/v1/secret/applicationa"):
+					q := r.URL.Query()
+					list := q.Get("list")
+					if list == "true" {
+						fmt.Fprintln(w, string(b))
+					} else {
+						fmt.Fprintln(w, `{"data": {"value": "yee"}}`)
+					}
+				default:
+					w.WriteHeader(404)
+					fmt.Fprintln(w, `{"errors": []}`)
+				}
+			}))
+	defer ts.Close()
+
+	client, err := testhelpers.GetTestClient(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := ioutil.TempFile(os.TempDir(), "secret-path-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	os.Setenv("VAULT_SECRETS_APPLICATIONA", "secret/applicationa")
+	defer os.Unsetenv("VAULT_SECRETS_APPLICATIONA")
+	config.SecretPayloadPath = file.Name()
+	config.Workers = 3
+
+	timeout := time.After(10 * time.Second)
+	done := make(chan bool)
+
+	go func() {
+		SecretFetcher(client, config)
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("secret fetcher is deadlocked")
+	case <-done:
+		// pass
+	}
+
+	secrets := make(map[string]string)
+	data, err := ioutil.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal(data, &secrets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1800, len(secrets))
+}


### PR DESCRIPTION
The previous implementation had the potential to encounter a worker deadlock due to the use of buffered channels with a length of 100. If there weren't enough workers to process the incoming data, that channel would reach capacity. 

---

- Implement `ReadPaths` in lieu of individual `AsyncRequestKeyPath` and `ReadSecretResult` functions

- Use a buffered channel for the secret reader so that secret definitions with >= 100 paths don't deadlock the worker

- Improve logging and error reporting

- Update the worker manager to react to os signals, ensuring the worker
pool is shut down cleanly

- Added a RWMutex to SecretDefinition so that the secrets map can be
locked for reading and writing