### PR TITLE
Ability to write secrets to paths whose parents do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 1.1.0 - Mar 19, 2020
 
--  introduces arbitrary suffix identifiers for Secret Definitions.
+- Introduces arbitrary suffix identifiers for Secret Definitions.
 
 ## 1.0.2 - Oct 16, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+## 1.1.5 - Unreleased
+
+- Update to go 1.16
+- Address a potential deadlock in the parallel secret reader
+- Secrets can be written to file paths whose parents do not exist; parents are created as needed
+
+## 1.1.4 - Oct 23, 2020
+
+- Fix panic when vault returns non-string types. string and map[string]interface{} are the only supported types at the moment.
+- Attempt to locate destination definitions that don't have a matching source definition. This provides some best effort backward compatibility to pre 1.1.0 versions
+
+## 1.1.3 - Oct 5, 2020 
+
+- Handle rate limiting responses returned from a vault
+
+## 1.1.2 - Sep 24, 2020
+
+- Introduce the option to output DAYTONA log events as structured data (JSON)
+
+## 1.1.1 - Mar 25, 2020
+
+- Introduce a Value Key prefix that can be used for retrieving a single value from a singular secret definition
+- Don't error when encountering a sub-path during a plural secret definition walk
+
+## 1.1.0 - Mar 19, 2020
+
+-  introduces arbitrary suffix identifiers for Secret Definitions.
+
+## 1.0.2 - Oct 16, 2019
+
+- Parallel secret fetching
+- Naive (no x509/pkix required) issuance of certs/keys from PKI backend
+- Minor documentation updates and bug fixes
+
+## 1.0.1 - Jun 20, 2019
+
+- Applied stricter linting
+- Tidy/update vendor
+- Minor documentation updates
+
+## 1.0.0 - May 7, 2019
+
+- Initial release of DAYTONA, a HashiCorp Vault client, but for servers and containers.

--- a/pkg/helpers/file.go
+++ b/pkg/helpers/file.go
@@ -1,0 +1,22 @@
+package helpers
+
+import (
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func WriteFile(path string, data []byte, perm fs.FileMode) error {
+	dir, _ := filepath.Split(path)
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(path, data, perm)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/helpers/file.go
+++ b/pkg/helpers/file.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -14,7 +13,7 @@ func WriteFile(path string, data []byte, perm fs.FileMode) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(path, data, perm)
+	err = os.WriteFile(path, data, perm)
 	if err != nil {
 		return err
 	}

--- a/pkg/helpers/file_test.go
+++ b/pkg/helpers/file_test.go
@@ -1,0 +1,42 @@
+package helpers
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileParents(t *testing.T) {
+	parentDir := os.TempDir()
+	td, err := ioutil.TempDir(parentDir, "*-iykyk")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(td)
+
+	err = WriteFile(filepath.Join(td, "levelone", "leveltwo", "test.log"), []byte("hi there"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = WriteFile(filepath.Join(td, "test.log"), []byte("helllo there"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	tf, err := ioutil.TempFile("", "*-iykyk")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(tf.Name())
+
+	err = WriteFile(tf.Name(), []byte("hey there"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -19,10 +19,10 @@ package pki
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	cfg "github.com/cruise-automation/daytona/pkg/config"
+	"github.com/cruise-automation/daytona/pkg/helpers"
 	"github.com/hashicorp/vault/api"
 	"github.com/rs/zerolog/log"
 )
@@ -73,12 +73,12 @@ func writeCertData(resp *api.Secret, certFile string, keyFile string, useCaChain
 		}
 	}
 
-	err := ioutil.WriteFile(certFile, certificate.Bytes(), 0600)
+	err := helpers.WriteFile(certFile, certificate.Bytes(), 0600)
 	if err != nil {
 		return fmt.Errorf("could not write certificate to file '%s': %s", certFile, err)
 	}
 
-	err = ioutil.WriteFile(keyFile, []byte(resp.Data["private_key"].(string)), 0600)
+	err = helpers.WriteFile(keyFile, []byte(resp.Data["private_key"].(string)), 0600)
 	if err != nil {
 		return fmt.Errorf("could not write private key to file '%s': %s", keyFile, err)
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"sync"
 
 	cfg "github.com/cruise-automation/daytona/pkg/config"
+	"github.com/cruise-automation/daytona/pkg/helpers"
 	"github.com/hashicorp/vault/api"
 	"github.com/rs/zerolog/log"
 )
@@ -242,7 +242,7 @@ func valueConverter(value interface{}) (string, error) {
 }
 
 func writeFile(path string, data []byte) error {
-	err := ioutil.WriteFile(path, data, 0600)
+	err := helpers.WriteFile(path, data, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously if a secret destination path was provided that didn't fully exist, DAYTONA would fail to write the secret. Parent directories are now created as needed in order to successfully write the secret to file.

Previous Success: `/tmp/ssshhhh.json`
Previous Failure: `/tmp/this/that/another/secret.json`

Current Success: `/tmp/ssshhhh.json`
Current Success: `/tmp/this/that/another/secret.json`