### PR TITLE
Introducing secret Unmarshal function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-cmd/daytona/daytona
-daytona
-coverage.out
+/cmd/daytona/daytona
+/daytona
+/coverage.out

--- a/pkg/daytona/options.go
+++ b/pkg/daytona/options.go
@@ -1,0 +1,45 @@
+package daytona
+
+import (
+	"github.com/hashicorp/vault/api"
+)
+
+type Option interface {
+	Apply(s *SecretUnmarshler)
+}
+
+// WithClient allows callers to provice a custom
+// vault client
+func WithClient(client *api.Client) Option {
+	return withClient{client}
+}
+
+type withClient struct{ c *api.Client }
+
+func (w withClient) Apply(s *SecretUnmarshler) {
+	s.client = w.c
+}
+
+// WithTokenString allows callers to provide a token
+// in the form of a string
+func WithTokenString(token string) Option {
+	return withTokenString{token}
+}
+
+type withTokenString struct{ token string }
+
+func (w withTokenString) Apply(s *SecretUnmarshler) {
+	s.tokenString = w.token
+}
+
+// WithTokenFile allows callers to provide a path
+// to a file where a vault token is stored
+func WithTokenFile(path string) Option {
+	return withTokenFile{path}
+}
+
+type withTokenFile struct{ path string }
+
+func (w withTokenFile) Apply(s *SecretUnmarshler) {
+	s.tokenFile = w.path
+}

--- a/pkg/daytona/options_test.go
+++ b/pkg/daytona/options_test.go
@@ -1,0 +1,70 @@
+package daytona
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+)
+
+var testToken = "THIS IS MY TOKEN"
+
+func TestOptionsWithClient(t *testing.T) {
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.SetToken(testToken)
+
+	u, err := NewSecretUnmarshler(WithClient(client))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if u.client.Token() != testToken {
+		// we purposely don't log api.Client.Token() in the
+		// unlikely event we pickup a production token
+		t.Fatalf("WithClient options is not working. exptected token %s, got something else...", testToken)
+	}
+}
+
+func TestOptionsWithTokenString(t *testing.T) {
+	u, err := NewSecretUnmarshler(WithTokenString(testToken))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if u.client.Token() != testToken {
+		// we purposely don't log api.Client.Token() in the
+		// unlikely event we pickup a production token
+		t.Fatalf("WithTokenString options is not working. exptected token %s, got something else...", testToken)
+	}
+}
+
+func TestOptionsWithTokenFile(t *testing.T) {
+	fileTokenContents := "THIS IS MY FILE TOKEN"
+	file, err := ioutil.TempFile("", "test-vault-token")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	_, err = file.Write([]byte(fileTokenContents))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u, err := NewSecretUnmarshler(WithTokenFile(file.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if u.client.Token() != fileTokenContents {
+		// we purposely don't log api.Client.Token() in the
+		// unlikely event we pickup a production token
+		t.Fatalf("WithTokenFile options is not working. exptected token %s, got something else...", testToken)
+	}
+}

--- a/pkg/daytona/unmarshal.go
+++ b/pkg/daytona/unmarshal.go
@@ -1,0 +1,162 @@
+package daytona
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+)
+
+const (
+	vaultTagPath = "vault_path"
+	vaultTagKey  = "vault_key"
+
+	vaultTagPathKey = "vault_path_key"
+
+	defaultVaultTagField = "value"
+)
+
+var ErrValueInput = errors.New("the provided value must be a struct pointer")
+
+// UnmarshalSecrets traverses the value v recursively looking for tagged fields that
+// can be populated with secret data using the provided client and optional apex.
+// If the apex is provided, the tag vault_path_key is appened to the apex to construct
+// the final secret path. If the tag vault_path is provided, the apex is ignored.
+// A default key of 'default' is used on each path, it can be overridden using the vault_key tag.
+//
+//  Apex of 'secret/application' provided, combined to form 'secret/application/db_password'
+//  Field string `vault_path_key:"db_password"`
+//
+//  Apex of 'secret/application' provided, with key override
+//  Field string `vault_path_key:"db_password" vault_key:"password"`
+//
+//  vault_path represents a full secret path to fetch
+//  Field string `vault_path:"secret/application/db_password"`
+//  Field string `vault_path:"secret/application/db_password" vault_key:"password"` // key override
+func UnmarshalSecrets(client *api.Client, v interface{}, apex string) error {
+	val := reflect.ValueOf(v)
+	if val.Kind() != reflect.Ptr {
+		return ErrValueInput
+	}
+
+	val = val.Elem()
+	if val.Kind() != reflect.Struct {
+		return ErrValueInput
+	}
+
+	for i := 0; i < val.NumField(); i++ {
+		path, valueIndex := parsePath(apex, val.Type().Field(i).Tag)
+
+		switch val.Field(i).Kind() {
+		case reflect.Struct:
+			err := UnmarshalSecrets(client, val.Field(i).Addr().Interface(), apex)
+			if err != nil {
+				return err
+			}
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if path == "" {
+				continue
+			}
+
+			var iv int64
+
+			v, err := fetchValue(client, path, valueIndex)
+			if err != nil {
+				return err
+			}
+			if val.Field(i).Kind() == reflect.Int64 && val.Field(i).Type().String() == "time.Duration" {
+				var d time.Duration
+				d, err = time.ParseDuration(v.(string))
+				if err != nil {
+					return err
+				}
+				iv = int64(d)
+			} else {
+				if value, err := v.(json.Number).Int64(); err == nil {
+					iv = value
+				}
+			}
+			val.Field(i).SetInt(iv)
+		case reflect.Float32, reflect.Float64:
+			if path == "" {
+				continue
+			}
+			v, err := fetchValue(client, path, valueIndex)
+			if err != nil {
+				return err
+			}
+			if value, err := v.(json.Number).Float64(); err == nil {
+				val.Field(i).SetFloat(value)
+			}
+		case reflect.String:
+			if path == "" {
+				continue
+			}
+			v, err := fetchValue(client, path, valueIndex)
+			if err != nil {
+				return err
+			}
+			if value := v.(string); value != "" {
+				val.Field(i).SetString(value)
+			}
+		case reflect.Bool:
+			if path == "" {
+				continue
+			}
+			v, err := fetchValue(client, path, valueIndex)
+			if err != nil {
+				return err
+			}
+			val.Field(i).SetBool(v.(bool))
+		default:
+			continue
+		}
+	}
+	return nil
+}
+
+func parsePath(apex string, tag reflect.StructTag) (path, valueIndex string) {
+	p, ok := tag.Lookup(vaultTagPath)
+	if ok {
+		path = p
+	} else {
+		// try to use an apex
+		if apex != "" {
+			p, ok := tag.Lookup(vaultTagPathKey)
+			if ok {
+				path = fmt.Sprintf("%s/%s", strings.TrimSuffix(apex, "/"), p)
+			}
+		}
+	}
+
+	vi, ok := tag.Lookup(vaultTagKey)
+	if !ok {
+		valueIndex = defaultVaultTagField
+	} else {
+		valueIndex = vi
+	}
+
+	return path, valueIndex
+}
+
+func fetchValue(client *api.Client, path, valueIndex string) (interface{}, error) {
+	secret, err := client.Logical().Read(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read secret %s: %w", path, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, errors.New("path did not return any data")
+	}
+
+	value := secret.Data[valueIndex]
+
+	if value == nil {
+		return nil, fmt.Errorf("could not extract value from data %s %s", path, valueIndex)
+	}
+
+	return value, nil
+}

--- a/pkg/daytona/unmarshal.go
+++ b/pkg/daytona/unmarshal.go
@@ -89,7 +89,7 @@ func UnmarshalSecrets(client *api.Client, v interface{}, opts ...UnmarshalSecret
 		path, valueIndex := parsePath(config.apex, val.Type().Field(i).Tag)
 		switch f.Kind() {
 		case reflect.Struct:
-			err := UnmarshalSecrets(client, f.Addr().Interface(), WithApex(config.apex))
+			err := UnmarshalSecrets(client, f.Addr().Interface(), opts...)
 			if err != nil {
 				return err
 			}

--- a/pkg/daytona/unmarshal.go
+++ b/pkg/daytona/unmarshal.go
@@ -41,7 +41,7 @@ func WithApex(apex string) UnmarshalSecretsOption {
 type withApex string
 
 func (w withApex) apply(c *unmarshalSecretsConfig) {
-	c.apex = string(w)
+	c.apex = strings.TrimSuffix(string(w), "/")
 }
 
 // UnmarshalSecrets traverses the value v recursively looking for tagged fields that
@@ -217,7 +217,7 @@ func parsePath(apex string, tag reflect.StructTag) (path, valueIndex string) {
 		if apex != "" {
 			p, ok := tag.Lookup(vaultTagPathKey)
 			if ok {
-				path = fmt.Sprintf("%s/%s", strings.TrimSuffix(apex, "/"), p)
+				path = fmt.Sprintf("%s/%s", apex, p)
 			}
 		}
 	}

--- a/pkg/daytona/unmarshal.go
+++ b/pkg/daytona/unmarshal.go
@@ -68,12 +68,14 @@ func UnmarshalSecrets(client *api.Client, v interface{}, apex string) error {
 			if err != nil {
 				return err
 			}
+
 			if val.Field(i).Kind() == reflect.Int64 && val.Field(i).Type().String() == "time.Duration" {
 				var d time.Duration
 				d, err = time.ParseDuration(v.(string))
 				if err != nil {
 					return err
 				}
+
 				iv = int64(d)
 			} else {
 				if value, err := v.(json.Number).Int64(); err == nil {

--- a/pkg/daytona/unmarshal_test.go
+++ b/pkg/daytona/unmarshal_test.go
@@ -8,27 +8,8 @@ import (
 	"time"
 
 	"github.com/cruise-automation/daytona/pkg/helpers/testhelpers"
-
 	"github.com/stretchr/testify/assert"
 )
-
-type ConfigWithSecrets struct {
-	Nothign    string
-	Password   string            `vault_path:"secret/application/password" vault_key:"password"`
-	DBPassword string            `vault_path_key:"password"`
-	AnInteger  int64             `vault_path_key:"password" vault_key:"an_int"`
-	AFloat     float64           `vault_path_key:"password" vault_key:"a_float"`
-	ABool      bool              `vault_path_key:"password" vault_key:"a_bool"`
-	ADuration  time.Duration     `vault_path_key:"password" vault_key:"a_duration"`
-	AMap       map[string]string `vault_path_key:"password" vault_key:"a_map"`
-	Slice      []string          `vault_path_key:"password" vault_key:"a_slice"`
-	AMismatch  float64           `vault_path_key:"password" vault_key:"a_mismatch"`
-	Embedded
-}
-
-type Embedded struct {
-	PrivateKey string `vault_path_key:"password" vault_key:"private_key"`
-}
 
 func TestUnmarshalSecret(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -41,10 +22,18 @@ func TestUnmarshalSecret(t *testing.T) {
 				  "value": "standard",
 				  "password": "nonstandard",
 				  "private_key": "BEGIN PRIVATE KEY",
+				  "a_bad_string": 9,
 				  "an_int": 12,
+				  "a_string_int": "12",
+				  "a_bad_int": "xxx",
 				  "a_float": 6.66,
+				  "a_string_float": "6.66",
+				  "a_bad_float": "xxx",
 				  "a_bool": true,
+				  "a_string_bool": "true",
+				  "a_bad_bool": "yee",
 				  "a_duration": "7h",
+				  "a_bad_duration": "hello",
 				  "a_mismatch": "7xL"
 				},
 				"lease_duration": 3600,
@@ -62,18 +51,141 @@ func TestUnmarshalSecret(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := ConfigWithSecrets{}
+	empty := struct{}{}
+	err = UnmarshalSecrets(client, empty, "secret/application")
+	assert.Equal(t, ErrValueInput, err)
 
-	err = UnmarshalSecrets(client, &cfg, "secret/application")
-	if err != nil {
-		t.Fatal(err)
+	normal := struct {
+		Hello string
+	}{Hello: "hi!"}
+	err = UnmarshalSecrets(client, &normal, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "hi!", normal.Hello)
+
+	aFullPath := struct {
+		Password string `vault_path:"secret/application/password" vault_key:"password"`
+	}{}
+	err = UnmarshalSecrets(client, &aFullPath, "secret/lol")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "nonstandard", aFullPath.Password)
+
+	stdApex := struct {
+		Password string `vault_path_key:"password"`
+	}{}
+	err = UnmarshalSecrets(client, &stdApex, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "standard", stdApex.Password)
+
+	var embedded struct {
+		Nested struct {
+			PrivateKey string `vault_path_key:"password" vault_key:"private_key"`
+		}
 	}
+	err = UnmarshalSecrets(client, &embedded, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "BEGIN PRIVATE KEY", embedded.Nested.PrivateKey)
 
-	assert.Equal(t, "standard", cfg.DBPassword)
-	assert.Equal(t, "nonstandard", cfg.Password)
-	assert.Equal(t, "BEGIN PRIVATE KEY", cfg.Embedded.PrivateKey)
-	assert.Equal(t, time.Hour*7, cfg.ADuration)
-	assert.Equal(t, 6.66, cfg.AFloat)
-	assert.Equal(t, int64(12), cfg.AnInteger)
-	assert.Equal(t, true, cfg.ABool)
+	aBadString := struct {
+		aBadString string `vault_path_key:"password" vault_key:"a_bad_string"`
+	}{}
+	err = UnmarshalSecrets(client, &aBadString, "secret/application")
+	assert.NotNil(t, err)
+
+	goodDuration := struct {
+		ADuration time.Duration `vault_path_key:"password" vault_key:"a_duration"`
+	}{}
+	err = UnmarshalSecrets(client, &goodDuration, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, time.Hour*7, goodDuration.ADuration)
+
+	invalidDuration := struct {
+		ADuration time.Duration `vault_path_key:"password" vault_key:"a_bad_duration"`
+	}{}
+	err = UnmarshalSecrets(client, &invalidDuration, "secret/application")
+	assert.Equal(t, `time: invalid duration "hello"`, err.Error())
+
+	aFloat := struct {
+		AFloat float64 `vault_path_key:"password" vault_key:"a_float"`
+	}{}
+	err = UnmarshalSecrets(client, &aFloat, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 6.66, aFloat.AFloat)
+
+	aStringFloat := struct {
+		AFloat float64 `vault_path_key:"password" vault_key:"a_string_float"`
+	}{}
+	err = UnmarshalSecrets(client, &aStringFloat, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 6.66, aStringFloat.AFloat)
+
+	aBadFloat := struct {
+		aBadFloat float64 `vault_path_key:"password" vault_key:"a_bad_float"`
+	}{}
+	err = UnmarshalSecrets(client, &aBadFloat, "secret/application")
+	assert.NotNil(t, err)
+
+	anInteger := struct {
+		AnInteger int64 `vault_path_key:"password" vault_key:"an_int"`
+	}{}
+	err = UnmarshalSecrets(client, &anInteger, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, int64(12), anInteger.AnInteger)
+
+	aStringInteger := struct {
+		AStringInteger int64 `vault_path_key:"password" vault_key:"a_string_int"`
+	}{}
+	err = UnmarshalSecrets(client, &aStringInteger, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, int64(12), aStringInteger.AStringInteger)
+
+	aBadInt := struct {
+		aBadInt int64 `vault_path_key:"password" vault_key:"a_bad_int"`
+	}{}
+	err = UnmarshalSecrets(client, &aBadInt, "secret/application")
+	assert.NotNil(t, err)
+
+	aBool := struct {
+		ABool bool `vault_path_key:"password" vault_key:"a_bool"`
+	}{}
+	err = UnmarshalSecrets(client, &aBool, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, true, aBool.ABool)
+
+	aStringBool := struct {
+		AStringBool bool `vault_path_key:"password" vault_key:"a_string_bool"`
+	}{}
+	err = UnmarshalSecrets(client, &aStringBool, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, true, aStringBool.AStringBool)
+
+	aBadBool := struct {
+		aBadBool bool `vault_path_key:"password" vault_key:"a_bad_bool"`
+	}{}
+	err = UnmarshalSecrets(client, &aBadBool, "secret/application")
+	assert.NotNil(t, err)
+
+	aMisMatch := struct {
+		AMismatch float64 `vault_path_key:"password" vault_key:"a_mismatch"`
+	}{}
+	err = UnmarshalSecrets(client, &aMisMatch, "secret/application")
+	assert.Equal(t, `strconv.ParseFloat: parsing "7xL": invalid syntax`, err.Error())
+
+	type x struct {
+		Value string `vault_path_key:"password"`
+	}
+	aThing := struct {
+		Thingy *x
+	}{}
+	err = UnmarshalSecrets(client, &aThing, "secret/application")
+	if err != nil {
+		fmt.Println(err)
+	}
+	assert.Equal(t, "standard", aThing.Thingy.Value)
+
+	aPtrField := struct {
+		Password *string `vault_path_key:"password"`
+	}{}
+	err = UnmarshalSecrets(client, &aPtrField, "secret/application")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "standard", *aPtrField.Password)
 }

--- a/pkg/daytona/unmarshal_test.go
+++ b/pkg/daytona/unmarshal_test.go
@@ -52,27 +52,27 @@ func TestUnmarshalSecret(t *testing.T) {
 	}
 
 	empty := struct{}{}
-	err = UnmarshalSecrets(client, empty, "secret/application")
+	err = UnmarshalSecrets(client, empty, WithApex("secret/application"))
 	assert.Equal(t, ErrValueInput, err)
 
 	normal := struct {
 		Hello string
 	}{Hello: "hi!"}
-	err = UnmarshalSecrets(client, &normal, "secret/application")
+	err = UnmarshalSecrets(client, &normal, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "hi!", normal.Hello)
 
 	aFullPath := struct {
 		Password string `vault_path:"secret/application/password" vault_key:"password"`
 	}{}
-	err = UnmarshalSecrets(client, &aFullPath, "secret/lol")
+	err = UnmarshalSecrets(client, &aFullPath)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "nonstandard", aFullPath.Password)
 
 	stdApex := struct {
 		Password string `vault_path_key:"password"`
 	}{}
-	err = UnmarshalSecrets(client, &stdApex, "secret/application")
+	err = UnmarshalSecrets(client, &stdApex, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "standard", stdApex.Password)
 
@@ -81,93 +81,93 @@ func TestUnmarshalSecret(t *testing.T) {
 			PrivateKey string `vault_path_key:"password" vault_key:"private_key"`
 		}
 	}
-	err = UnmarshalSecrets(client, &embedded, "secret/application")
+	err = UnmarshalSecrets(client, &embedded, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "BEGIN PRIVATE KEY", embedded.Nested.PrivateKey)
 
 	aBadString := struct {
 		aBadString string `vault_path_key:"password" vault_key:"a_bad_string"`
 	}{}
-	err = UnmarshalSecrets(client, &aBadString, "secret/application")
+	err = UnmarshalSecrets(client, &aBadString, WithApex("secret/application"))
 	assert.NotNil(t, err)
 
 	goodDuration := struct {
 		ADuration time.Duration `vault_path_key:"password" vault_key:"a_duration"`
 	}{}
-	err = UnmarshalSecrets(client, &goodDuration, "secret/application")
+	err = UnmarshalSecrets(client, &goodDuration, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, time.Hour*7, goodDuration.ADuration)
 
 	invalidDuration := struct {
 		ADuration time.Duration `vault_path_key:"password" vault_key:"a_bad_duration"`
 	}{}
-	err = UnmarshalSecrets(client, &invalidDuration, "secret/application")
+	err = UnmarshalSecrets(client, &invalidDuration, WithApex("secret/application"))
 	assert.Equal(t, `time: invalid duration "hello"`, err.Error())
 
 	aFloat := struct {
 		AFloat float64 `vault_path_key:"password" vault_key:"a_float"`
 	}{}
-	err = UnmarshalSecrets(client, &aFloat, "secret/application")
+	err = UnmarshalSecrets(client, &aFloat, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 6.66, aFloat.AFloat)
 
 	aStringFloat := struct {
 		AFloat float64 `vault_path_key:"password" vault_key:"a_string_float"`
 	}{}
-	err = UnmarshalSecrets(client, &aStringFloat, "secret/application")
+	err = UnmarshalSecrets(client, &aStringFloat, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 6.66, aStringFloat.AFloat)
 
 	aBadFloat := struct {
 		aBadFloat float64 `vault_path_key:"password" vault_key:"a_bad_float"`
 	}{}
-	err = UnmarshalSecrets(client, &aBadFloat, "secret/application")
+	err = UnmarshalSecrets(client, &aBadFloat, WithApex("secret/application"))
 	assert.NotNil(t, err)
 
 	anInteger := struct {
 		AnInteger int64 `vault_path_key:"password" vault_key:"an_int"`
 	}{}
-	err = UnmarshalSecrets(client, &anInteger, "secret/application")
+	err = UnmarshalSecrets(client, &anInteger, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, int64(12), anInteger.AnInteger)
 
 	aStringInteger := struct {
 		AStringInteger int64 `vault_path_key:"password" vault_key:"a_string_int"`
 	}{}
-	err = UnmarshalSecrets(client, &aStringInteger, "secret/application")
+	err = UnmarshalSecrets(client, &aStringInteger, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, int64(12), aStringInteger.AStringInteger)
 
 	aBadInt := struct {
 		aBadInt int64 `vault_path_key:"password" vault_key:"a_bad_int"`
 	}{}
-	err = UnmarshalSecrets(client, &aBadInt, "secret/application")
+	err = UnmarshalSecrets(client, &aBadInt, WithApex("secret/application"))
 	assert.NotNil(t, err)
 
 	aBool := struct {
 		ABool bool `vault_path_key:"password" vault_key:"a_bool"`
 	}{}
-	err = UnmarshalSecrets(client, &aBool, "secret/application")
+	err = UnmarshalSecrets(client, &aBool, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, true, aBool.ABool)
 
 	aStringBool := struct {
 		AStringBool bool `vault_path_key:"password" vault_key:"a_string_bool"`
 	}{}
-	err = UnmarshalSecrets(client, &aStringBool, "secret/application")
+	err = UnmarshalSecrets(client, &aStringBool, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, true, aStringBool.AStringBool)
 
 	aBadBool := struct {
 		aBadBool bool `vault_path_key:"password" vault_key:"a_bad_bool"`
 	}{}
-	err = UnmarshalSecrets(client, &aBadBool, "secret/application")
+	err = UnmarshalSecrets(client, &aBadBool, WithApex("secret/application"))
 	assert.NotNil(t, err)
 
 	aMisMatch := struct {
 		AMismatch float64 `vault_path_key:"password" vault_key:"a_mismatch"`
 	}{}
-	err = UnmarshalSecrets(client, &aMisMatch, "secret/application")
+	err = UnmarshalSecrets(client, &aMisMatch, WithApex("secret/application"))
 	assert.Equal(t, `strconv.ParseFloat: parsing "7xL": invalid syntax`, err.Error())
 
 	type x struct {
@@ -176,7 +176,7 @@ func TestUnmarshalSecret(t *testing.T) {
 	aThing := struct {
 		Thingy *x
 	}{}
-	err = UnmarshalSecrets(client, &aThing, "secret/application")
+	err = UnmarshalSecrets(client, &aThing, WithApex("secret/application"))
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -185,7 +185,7 @@ func TestUnmarshalSecret(t *testing.T) {
 	aPtrField := struct {
 		Password *string `vault_path_key:"password"`
 	}{}
-	err = UnmarshalSecrets(client, &aPtrField, "secret/application")
+	err = UnmarshalSecrets(client, &aPtrField, WithApex("secret/application"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "standard", *aPtrField.Password)
 }

--- a/pkg/daytona/unmarshal_test.go
+++ b/pkg/daytona/unmarshal_test.go
@@ -22,6 +22,7 @@ type ConfigWithSecrets struct {
 	ADuration  time.Duration     `vault_path_key:"password" vault_key:"a_duration"`
 	AMap       map[string]string `vault_path_key:"password" vault_key:"a_map"`
 	Slice      []string          `vault_path_key:"password" vault_key:"a_slice"`
+	AMismatch  float64           `vault_path_key:"password" vault_key:"a_mismatch"`
 	Embedded
 }
 
@@ -43,7 +44,8 @@ func TestUnmarshalSecret(t *testing.T) {
 				  "an_int": 12,
 				  "a_float": 6.66,
 				  "a_bool": true,
-				  "a_duration": "7h"
+				  "a_duration": "7h",
+				  "a_mismatch": "7xL"
 				},
 				"lease_duration": 3600,
 				"lease_id": "",

--- a/pkg/daytona/unmarshal_test.go
+++ b/pkg/daytona/unmarshal_test.go
@@ -1,0 +1,77 @@
+package daytona
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cruise-automation/daytona/pkg/helpers/testhelpers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ConfigWithSecrets struct {
+	Nothign    string
+	Password   string            `vault_path:"secret/application/password" vault_key:"password"`
+	DBPassword string            `vault_path_key:"password"`
+	AnInteger  int64             `vault_path_key:"password" vault_key:"an_int"`
+	AFloat     float64           `vault_path_key:"password" vault_key:"a_float"`
+	ABool      bool              `vault_path_key:"password" vault_key:"a_bool"`
+	ADuration  time.Duration     `vault_path_key:"password" vault_key:"a_duration"`
+	AMap       map[string]string `vault_path_key:"password" vault_key:"a_map"`
+	Slice      []string          `vault_path_key:"password" vault_key:"a_slice"`
+	Embedded
+}
+
+type Embedded struct {
+	PrivateKey string `vault_path_key:"password" vault_key:"private_key"`
+}
+
+func TestUnmarshalSecret(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/secret/application/password":
+			fmt.Fprintln(w, `
+			{
+				"auth": null,
+				"data": {
+				  "value": "standard",
+				  "password": "nonstandard",
+				  "private_key": "BEGIN PRIVATE KEY",
+				  "an_int": 12,
+				  "a_float": 6.66,
+				  "a_bool": true,
+				  "a_duration": "7h"
+				},
+				"lease_duration": 3600,
+				"lease_id": "",
+				"renewable": false
+			  }
+			`)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+	client, err := testhelpers.GetTestClient(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ConfigWithSecrets{}
+
+	err = UnmarshalSecrets(client, &cfg, "secret/application")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "standard", cfg.DBPassword)
+	assert.Equal(t, "nonstandard", cfg.Password)
+	assert.Equal(t, "BEGIN PRIVATE KEY", cfg.Embedded.PrivateKey)
+	assert.Equal(t, time.Hour*7, cfg.ADuration)
+	assert.Equal(t, 6.66, cfg.AFloat)
+	assert.Equal(t, int64(12), cfg.AnInteger)
+	assert.Equal(t, true, cfg.ABool)
+}

--- a/pkg/daytona/unmarshal_test.go
+++ b/pkg/daytona/unmarshal_test.go
@@ -1,6 +1,8 @@
 package daytona
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,36 +13,61 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUnmarshalSecret(t *testing.T) {
+var testPayload = map[string]interface{}{
+	"auth": nil,
+	"data": map[string]interface{}{
+		"value":          "standard",
+		"password":       "nonstandard",
+		"private_key":    "BEGIN PRIVATE KEY",
+		"a_bad_string":   9,
+		"an_int":         12,
+		"a_string_int":   "12",
+		"a_bad_int":      "xxx",
+		"a_float":        6.66,
+		"a_string_float": "6.66",
+		"a_bad_float":    "xxx",
+		"a_bool":         true,
+		"a_string_bool":  "true",
+		"a_bad_bool":     "yee",
+		"a_duration":     "7h",
+		"a_bad_duration": "hello",
+		"a_mismatch":     "7xL",
+	},
+	"lease_duration": 3600,
+	"lease_id":       "",
+	"renewable":      false,
+}
+
+func generateMuliKeyPayload() (string, error) {
+	b, err := json.Marshal(testPayload)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func TestUnmarshalSecretDataKeys(t *testing.T) {
+	tp, err := generateMuliKeyPayload()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/secret/application/password":
+			fmt.Fprintln(w, tp)
+		case "/v1/secret/top-level/API_KEY":
 			fmt.Fprintln(w, `
-			{
-				"auth": null,
-				"data": {
-				  "value": "standard",
-				  "password": "nonstandard",
-				  "private_key": "BEGIN PRIVATE KEY",
-				  "a_bad_string": 9,
-				  "an_int": 12,
-				  "a_string_int": "12",
-				  "a_bad_int": "xxx",
-				  "a_float": 6.66,
-				  "a_string_float": "6.66",
-				  "a_bad_float": "xxx",
-				  "a_bool": true,
-				  "a_string_bool": "true",
-				  "a_bad_bool": "yee",
-				  "a_duration": "7h",
-				  "a_bad_duration": "hello",
-				  "a_mismatch": "7xL"
-				},
-				"lease_duration": 3600,
-				"lease_id": "",
-				"renewable": false
-			  }
-			`)
+				{
+					"auth": null,
+					"data": {
+					  "value": "THIS_IS_MY_API_KEY"
+					},
+					"lease_duration": 3600,
+					"lease_id": "",
+					"renewable": false
+				  }
+				`)
 		default:
 			w.WriteHeader(404)
 		}
@@ -51,141 +78,222 @@ func TestUnmarshalSecret(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	secret, err := NewSecretUnmarshler(WithClient(client))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testData := testPayload["data"].(map[string]interface{})
+
+	// generic type input validation
 	empty := struct{}{}
-	err = UnmarshalSecrets(client, empty, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/applicaiton", empty)
 	assert.Equal(t, ErrValueInput, err)
 
+	var tst string
+	err = secret.Unmarshal(context.TODO(), "secret/applicaiton", tst)
+	assert.Equal(t, ErrValueInput, err)
+
+	// unaffected fields
 	normal := struct {
 		Hello string
+		Empty string
 	}{Hello: "hi!"}
-	err = UnmarshalSecrets(client, &normal, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/applicaiton", &normal)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "hi!", normal.Hello)
+	assert.Equal(t, "", normal.Empty)
+
+	conflictingTags := struct {
+		Value string `vault_path_key:"password" vault_data_key:"value"`
+	}{}
+	err = secret.Unmarshal(context.TODO(), "secret/application", &conflictingTags)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", conflictingTags.Value)
+
+	aValue := struct {
+		Value string `vault_data_key:"value"`
+	}{}
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aValue)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, testData["value"], aValue.Value)
 
 	aFullPath := struct {
-		Password string `vault_path:"secret/application/password" vault_key:"password"`
+		Password string `vault_data_key:"password"`
 	}{}
-	err = UnmarshalSecrets(client, &aFullPath)
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aFullPath)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "nonstandard", aFullPath.Password)
-
-	stdApex := struct {
-		Password string `vault_path_key:"password"`
-	}{}
-	err = UnmarshalSecrets(client, &stdApex, WithApex("secret/application"))
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "standard", stdApex.Password)
+	assert.Equal(t, testData["password"], aFullPath.Password)
 
 	var embedded struct {
 		Nested struct {
-			PrivateKey string `vault_path_key:"password" vault_key:"private_key"`
+			PrivateKey string `vault_data_key:"private_key"`
 		}
 	}
-	err = UnmarshalSecrets(client, &embedded, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &embedded)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "BEGIN PRIVATE KEY", embedded.Nested.PrivateKey)
+	assert.Equal(t, testData["private_key"], embedded.Nested.PrivateKey)
 
 	aBadString := struct {
-		aBadString string `vault_path_key:"password" vault_key:"a_bad_string"`
+		aBadString string `vault_data_key:"a_bad_string"`
 	}{}
-	err = UnmarshalSecrets(client, &aBadString, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aBadString)
 	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "expected a string")
 
 	goodDuration := struct {
-		ADuration time.Duration `vault_path_key:"password" vault_key:"a_duration"`
+		ADuration time.Duration `vault_data_key:"a_duration"`
 	}{}
-	err = UnmarshalSecrets(client, &goodDuration, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &goodDuration)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, time.Hour*7, goodDuration.ADuration)
 
 	invalidDuration := struct {
-		ADuration time.Duration `vault_path_key:"password" vault_key:"a_bad_duration"`
+		ADuration time.Duration `vault_data_key:"a_bad_duration"`
 	}{}
-	err = UnmarshalSecrets(client, &invalidDuration, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &invalidDuration)
 	assert.Equal(t, `time: invalid duration "hello"`, err.Error())
 
 	aFloat := struct {
-		AFloat float64 `vault_path_key:"password" vault_key:"a_float"`
+		AFloat float64 `vault_data_key:"a_float"`
 	}{}
-	err = UnmarshalSecrets(client, &aFloat, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aFloat)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, 6.66, aFloat.AFloat)
+	assert.Equal(t, testData["a_float"], aFloat.AFloat)
 
 	aStringFloat := struct {
-		AFloat float64 `vault_path_key:"password" vault_key:"a_string_float"`
+		AFloat float64 `vault_data_key:"a_string_float"`
 	}{}
-	err = UnmarshalSecrets(client, &aStringFloat, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aStringFloat)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, 6.66, aStringFloat.AFloat)
+	assert.Equal(t, testData["a_float"], aStringFloat.AFloat)
 
 	aBadFloat := struct {
-		aBadFloat float64 `vault_path_key:"password" vault_key:"a_bad_float"`
+		aBadFloat float64 `vault_data_key:"a_bad_float"`
 	}{}
-	err = UnmarshalSecrets(client, &aBadFloat, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aBadFloat)
 	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("parsing %q", testData["a_bad_float"]))
 
 	anInteger := struct {
-		AnInteger int64 `vault_path_key:"password" vault_key:"an_int"`
+		AnInteger int `vault_data_key:"an_int"`
 	}{}
-	err = UnmarshalSecrets(client, &anInteger, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &anInteger)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, int64(12), anInteger.AnInteger)
+	assert.Equal(t, testData["an_int"], anInteger.AnInteger)
 
 	aStringInteger := struct {
-		AStringInteger int64 `vault_path_key:"password" vault_key:"a_string_int"`
+		AStringInteger int `vault_data_key:"a_string_int"`
 	}{}
-	err = UnmarshalSecrets(client, &aStringInteger, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aStringInteger)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, int64(12), aStringInteger.AStringInteger)
+	assert.Equal(t, testData["an_int"], aStringInteger.AStringInteger)
 
 	aBadInt := struct {
-		aBadInt int64 `vault_path_key:"password" vault_key:"a_bad_int"`
+		aBadInt int64 `vault_data_key:"a_bad_int"`
 	}{}
-	err = UnmarshalSecrets(client, &aBadInt, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aBadInt)
 	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("parsing %q", testData["a_bad_int"]))
 
 	aBool := struct {
-		ABool bool `vault_path_key:"password" vault_key:"a_bool"`
+		ABool bool `vault_data_key:"a_bool"`
 	}{}
-	err = UnmarshalSecrets(client, &aBool, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aBool)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, true, aBool.ABool)
+	assert.Equal(t, testData["a_bool"], aBool.ABool)
 
 	aStringBool := struct {
-		AStringBool bool `vault_path_key:"password" vault_key:"a_string_bool"`
+		AStringBool bool `vault_data_key:"a_string_bool"`
 	}{}
-	err = UnmarshalSecrets(client, &aStringBool, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aStringBool)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, true, aStringBool.AStringBool)
+	assert.Equal(t, testData["a_bool"], aStringBool.AStringBool)
 
 	aBadBool := struct {
-		aBadBool bool `vault_path_key:"password" vault_key:"a_bad_bool"`
+		aBadBool bool `vault_data_key:"a_bad_bool"`
 	}{}
-	err = UnmarshalSecrets(client, &aBadBool, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aBadBool)
 	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("parsing %q", testData["a_bad_bool"]))
 
 	aMisMatch := struct {
-		AMismatch float64 `vault_path_key:"password" vault_key:"a_mismatch"`
+		AMismatch float64 `vault_data_key:"a_mismatch"`
 	}{}
-	err = UnmarshalSecrets(client, &aMisMatch, WithApex("secret/application"))
-	assert.Equal(t, `strconv.ParseFloat: parsing "7xL": invalid syntax`, err.Error())
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aMisMatch)
+	assert.Equal(t, fmt.Sprintf(`strconv.ParseFloat: parsing %q: invalid syntax`, testData["a_mismatch"]), err.Error())
 
 	type x struct {
-		Value string `vault_path_key:"password"`
+		Value string `vault_data_key:"password"`
 	}
-	aThing := struct {
+	aStructWithPointer := struct {
 		Thingy *x
 	}{}
-	err = UnmarshalSecrets(client, &aThing, WithApex("secret/application"))
-	if err != nil {
-		fmt.Println(err)
-	}
-	assert.Equal(t, "standard", aThing.Thingy.Value)
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aStructWithPointer)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, testData["password"], aStructWithPointer.Thingy.Value)
 
 	aPtrField := struct {
-		Password *string `vault_path_key:"password"`
+		Password *string `vault_data_key:"password"`
 	}{}
-	err = UnmarshalSecrets(client, &aPtrField, WithApex("secret/application"))
+	err = secret.Unmarshal(context.TODO(), "secret/application/password", &aPtrField)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "standard", *aPtrField.Password)
+	assert.Equal(t, testData["password"], *aPtrField.Password)
+}
+
+func TestUnmarshalSecretPathKeys(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/secret/top-level/API_KEY":
+			fmt.Fprintln(w, `
+				{
+					"auth": null,
+					"data": {
+					  "value": "THIS_IS_MY_API_KEY"
+					},
+					"lease_duration": 3600,
+					"lease_id": "",
+					"renewable": false
+				  }
+				`)
+		case "/v1/secret/top-level/SECRET_KEY":
+			fmt.Fprintln(w, `
+					{
+						"auth": null,
+						"data": {
+						  "secret": "shhhh"
+						},
+						"lease_duration": 3600,
+						"lease_id": "",
+						"renewable": false
+					  }
+					`)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+	client, err := testhelpers.GetTestClient(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secret, err := NewSecretUnmarshler(WithClient(client))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pathKey := struct {
+		Password string `vault_path_key:"API_KEY"`
+	}{}
+	err = secret.Unmarshal(context.TODO(), "secret/top-level", &pathKey)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "THIS_IS_MY_API_KEY", pathKey.Password)
+
+	pathKeyAltDatKey := struct {
+		Secret string `vault_path_key:"SECRET_KEY" vault_path_data_key:"secret"`
+	}{}
+	err = secret.Unmarshal(context.TODO(), "secret/top-level", &pathKeyAltDatKey)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "shhhh", pathKeyAltDatKey.Secret)
 }


### PR DESCRIPTION
Introducing a way to populate go structs with secret data from Vault.

`SecretUnmarshler` reads data from Vault and stores the result(s) in the a provided struct. This can be useful to inject sensitive configuration items directly into config structs.

The following field types are currently supported:

- struct
- string
- bool
- time.Duration
- signed ints
- float32, float64

**Secret Data Example 1**: Consider the design of the following secret path: `secret/application`, that contains
several sub-keys:

- API_KEY - the data being stored in the data key 'value'
- DB_PASSWORD - the data being stored in the data key 'value'

Reading the path `secret/application/api_key` returns the data:

```
{
  "data": {
    "value": "anapikey"
  }
}
```

Reading the path  `secret/application/db_password` returns the data:

```
{
  "data": {
    "value": "adbpassword"
  }
}
```

**Secret Data Example 2**: Consider the design of the following secret path: `secret/application/configs`, that contains
several data keys

- api_key
- db_password

Reading the path  `secret/application/configs` returns the data:

```
{
  "data": {
    "api_key": "anapikey",
    "db_password": "adbpassword"
  }
}
```

---

### Usage Example 1

A field tagged with `vault_path_key` implies that the apex is a top-level secret path, and the value provided by `vault_path_key` is the suffix key in the path. The full final path will be a combination of the apex and the path key. e.g. Using the example # 1 above, an apex of `secret/application` with a `vault_path_key` of `db_password`, will attempt to read the data stored in `secret/application/db_password` and store the returned valie in the field `DBPassword`. By default a data key of 'value' is used. The data key can be customized via the tag `vault_path_data_key`

```
type Config struct {
	APIKey     string `vault_path_key:"api_key"`
	DBPassword string `vault_path_key:"db_password"`
}

secret, err := daytona.NewSecretUnmarshler()
if err != nil {
	panic(err)
}

c := Config{}

err = secret.Unmarshal("secret/application", &c)
if err != nil {
	panic(err)
}
```

### Usage Example 2

A field tagged with `vault_data_key` implies that the apex is a full, final secret path and the value provided by `vault_data_key` is the name of the data key. e.g. Using the example # 2 above, an apex of `secret/application/configs`
with a `vault_data_key` of `db_password`, will attempt to read the data stored in `secret/application/configs`, referencing
the `db_password` data key and storing the returned value in the field `DBPassword`.

```
type Config struct {
	APIKey     string `vault_data_key:"api_key"`
	DBPassword string `vault_data_key:"db_password"`
}

secret, err := daytona.NewSecretUnmarshler()
if err != nil {
	panic(err)
}

c := Config{}

err = secret.Unmarshal("secret/application/configs", &c)
if err != nil {
	panic(err)
}
```
