### PR TITLE
Simplify auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ spec:
       env:
       - name: AUTH_METHOD
         value: "k8S"
-      - name : K8S_AUTH_MOUNT
+      - name : AUTH_MOUNT
         value: "kubernetes-gcp-dev-cluster"
       - name: SECRET_ENV
         value: "true"
@@ -502,23 +502,18 @@ Usage
 Usage of ./daytona:
   -address string
       Sets the vault server address. The default vault address or VAULT_ADDR environment variable is used if this is not supplied
-  -auth-mount string
   -auto-renew
       if enabled, starts the token renewal service (env: AUTO_RENEW)
   -auth-method
       select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH_METHOD)
   -entrypoint
       if enabled, execs the command after the separator (--) when done. mostly useful with -secret-env (env: ENTRYPOINT)
-  -gcp-auth-mount string
-      the vault mount where gcp auth takes place (env: GCP_AUTH_MOUNT) (default "gcp")
+  -auth-mount string
+      the vault mount where auth takes place (env: AUTH_MOUNT)
   -gcp-svc-acct string
       the name of the service account authenticating (env: GCP_SVC_ACCT)
-  -iam-auth-mount string
-      the vault mount where iam auth takes place (env: IAM_AUTH_MOUNT) (default "aws")
   -infinite-auth
       infinitely attempt to authenticate (env: INFINITE_AUTH)
-  -k8s-auth-mount string
-      the vault mount where k8s auth takes place (env: K8S_AUTH_MOUNT, note: will infer via k8s metadata api if left unset) (default "kubernetes")
   -k8s-token-path string
       kubernetes service account JWT token path (env: K8S_TOKEN_PATH) (default "/var/run/secrets/kubernetes.io/serviceaccount/token")
   -log-level string

--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ spec:
       - name: vault-secrets
         mountPath: /home/vault
       env:
-      - name: K8S_AUTH
-        value: "true"
+      - name: AUTH
+        value: "k8S"
       - name : K8S_AUTH_MOUNT
         value: "kubernetes-gcp-dev-cluster"
       - name: SECRET_ENV
@@ -352,7 +352,7 @@ Assume you have the following Vault AWS Auth Role, `vault-role-name`:
 ```
 
 ```
-VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -iam-auth -token-path /home/vault/.vault-token -vault-auth-role vault-role-name
+VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -auth=AWS -token-path /home/vault/.vault-token -vault-auth-role vault-role-name
 ```
 
 The execution example above (assuming a successful authentication) would yield a vault token at `/home/vault/.vault-token` and any specified secrets written to `/home/vault/secrets` as
@@ -380,7 +380,7 @@ as a representation of the following vault data:
 In a `Dockerfile`:
 
 ```dockerfile
-ENTRYPOINT [ "./daytona", "-secret-env", "-iam-auth", "-vault-auth-role", "vault-role-name", "-entrypoint", "--" ]
+ENTRYPOINT [ "./daytona", "-secret-env", "-auth", "AWS", "-vault-auth-role", "vault-role-name", "-entrypoint", "--" ]
 ```
 
 combined with supplying the following during a `docker run`:
@@ -417,7 +417,7 @@ as a representation of the following vault data:
 In a `Dockerfile`:
 
 ```dockerfile
-ENTRYPOINT [ "./daytona", "-iam-auth", "-vault-auth-role", "vault-role-name", "-pki-issuer", "pki-backend", "-pki-role", "my-role", "-pki-domains", "www.example.com", "-pki-cert", "/etc/cert.pem", "-pki-privkey", "/etc/key.pem", "-pki-use-ca-chain", -entrypoint", "--" ]
+ENTRYPOINT [ "./daytona", "-auth", "AWS", "-vault-auth-role", "vault-role-name", "-pki-issuer", "pki-backend", "-pki-role", "my-role", "-pki-domains", "www.example.com", "-pki-cert", "/etc/cert.pem", "-pki-privkey", "/etc/key.pem", "-pki-use-ca-chain", -entrypoint", "--" ]
 ```
 
 Given a PKI backend issuer role located at `pki-backend/issue/my-role`, and `update` permissions granted to `vault-role-name` on this path, Daytona will request a certificate for `www.example.com` from Vault, placing the certificate (with CA chain) and private key in `/etc`.
@@ -449,7 +449,7 @@ Assume you have the following Vault GCP Auth Role:
 ```
 
 ```
-VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -gcp-auth -gcp-svc-acct cruise-automation-sa@my-project.iam.gserviceaccount.com -token-path /home/vault/.vault-token -vault-auth-role vault-gcp-role-name
+VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -auth=GCP -gcp-svc-acct cruise-automation-sa@my-project.iam.gserviceaccount.com -token-path /home/vault/.vault-token -vault-auth-role vault-gcp-role-name
 ```
 
 The execution example above (assuming a successful authentication) would yield a vault token at `/home/vault/.vault-token` and any specified secrets written to `/home/vault/secrets` as
@@ -505,24 +505,18 @@ Usage of ./daytona:
   -auth-mount string
   -auto-renew
       if enabled, starts the token renewal service (env: AUTO_RENEW)
-  -aws-auth
-      select AWS IAM vault auth as the vault authentication mechanism (env: IAM_AUTH)
+  -auth
+      select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH)
   -entrypoint
       if enabled, execs the command after the separator (--) when done. mostly useful with -secret-env (env: ENTRYPOINT)
-  -gcp-auth
-      select Google Cloud Platform IAM auth as the vault authentication mechanism (env: GCP_AUTH)
   -gcp-auth-mount string
       the vault mount where gcp auth takes place (env: GCP_AUTH_MOUNT) (default "gcp")
   -gcp-svc-acct string
       the name of the service account authenticating (env: GCP_SVC_ACCT)
-  -iam-auth
-      (legacy) select AWS IAM vault auth as the vault authentication mechanism (env: IAM_AUTH)
   -iam-auth-mount string
       the vault mount where iam auth takes place (env: IAM_AUTH_MOUNT) (default "aws")
   -infinite-auth
       infinitely attempt to authenticate (env: INFINITE_AUTH)
-  -k8s-auth
-      select kubernetes vault auth as the vault authentication mechanism (env: K8S_AUTH)
   -k8s-auth-mount string
       the vault mount where k8s auth takes place (env: K8S_AUTH_MOUNT, note: will infer via k8s metadata api if left unset) (default "kubernetes")
   -k8s-token-path string

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ spec:
       - name: vault-secrets
         mountPath: /home/vault
       env:
-      - name: AUTH
+      - name: AUTH_METHOD
         value: "k8S"
       - name : K8S_AUTH_MOUNT
         value: "kubernetes-gcp-dev-cluster"
@@ -351,8 +351,8 @@ Assume you have the following Vault AWS Auth Role, `vault-role-name`:
 }
 ```
 
-```
-VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -auth=AWS -token-path /home/vault/.vault-token -vault-auth-role vault-role-name
+```sh
+VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -auth-method=AWS -token-path /home/vault/.vault-token -vault-auth-role vault-role-name
 ```
 
 The execution example above (assuming a successful authentication) would yield a vault token at `/home/vault/.vault-token` and any specified secrets written to `/home/vault/secrets` as
@@ -380,7 +380,7 @@ as a representation of the following vault data:
 In a `Dockerfile`:
 
 ```dockerfile
-ENTRYPOINT [ "./daytona", "-secret-env", "-auth", "AWS", "-vault-auth-role", "vault-role-name", "-entrypoint", "--" ]
+ENTRYPOINT [ "./daytona", "-secret-env", "-auth-method", "AWS", "-vault-auth-role", "vault-role-name", "-entrypoint", "--" ]
 ```
 
 combined with supplying the following during a `docker run`:
@@ -417,7 +417,7 @@ as a representation of the following vault data:
 In a `Dockerfile`:
 
 ```dockerfile
-ENTRYPOINT [ "./daytona", "-auth", "AWS", "-vault-auth-role", "vault-role-name", "-pki-issuer", "pki-backend", "-pki-role", "my-role", "-pki-domains", "www.example.com", "-pki-cert", "/etc/cert.pem", "-pki-privkey", "/etc/key.pem", "-pki-use-ca-chain", -entrypoint", "--" ]
+ENTRYPOINT [ "./daytona", "-auth-method", "AWS", "-vault-auth-role", "vault-role-name", "-pki-issuer", "pki-backend", "-pki-role", "my-role", "-pki-domains", "www.example.com", "-pki-cert", "/etc/cert.pem", "-pki-privkey", "/etc/key.pem", "-pki-use-ca-chain", -entrypoint", "--" ]
 ```
 
 Given a PKI backend issuer role located at `pki-backend/issue/my-role`, and `update` permissions granted to `vault-role-name` on this path, Daytona will request a certificate for `www.example.com` from Vault, placing the certificate (with CA chain) and private key in `/etc`.
@@ -448,8 +448,8 @@ Assume you have the following Vault GCP Auth Role:
 }
 ```
 
-```
-VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -auth=GCP -gcp-svc-acct cruise-automation-sa@my-project.iam.gserviceaccount.com -token-path /home/vault/.vault-token -vault-auth-role vault-gcp-role-name
+```sh
+VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -auth-method=GCP -gcp-svc-acct cruise-automation-sa@my-project.iam.gserviceaccount.com -token-path /home/vault/.vault-token -vault-auth-role vault-gcp-role-name
 ```
 
 The execution example above (assuming a successful authentication) would yield a vault token at `/home/vault/.vault-token` and any specified secrets written to `/home/vault/secrets` as
@@ -505,8 +505,8 @@ Usage of ./daytona:
   -auth-mount string
   -auto-renew
       if enabled, starts the token renewal service (env: AUTO_RENEW)
-  -auth
-      select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH)
+  -auth-method
+      select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH_METHOD)
   -entrypoint
       if enabled, execs the command after the separator (--) when done. mostly useful with -secret-env (env: ENTRYPOINT)
   -gcp-auth-mount string

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/cruise-automation/daytona/pkg/auth"
@@ -48,7 +49,11 @@ const (
 )
 
 func init() {
-	flag.StringVar(&config.AuthMethod, "auth-method", "", "Select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH_METHOD)")
+	flag.Func("auth-method", "Select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH_METHOD)", func(authMethod string) error {
+		upperAuthMethod := strings.ToUpper(authMethod)
+		config.AuthMethod = cfg.AuthMethod(upperAuthMethod)
+		return nil
+	})
 	flag.StringVar(&config.VaultAddress, "address", "", "Sets the vault server address. The default vault address or VAULT_ADDR environment variable is used if this is not supplied")
 	flag.StringVar(&config.TokenPath, "token-path", cfg.BuildDefaultConfigItem("TOKEN_PATH", "~/.vault-token"), "a full file path where a token will be read from/written to (env: TOKEN_PATH)")
 	flag.StringVar(&config.K8STokenPath, "k8s-token-path", cfg.BuildDefaultConfigItem("K8S_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"), "kubernetes service account jtw token path (env: K8S_TOKEN_PATH)")
@@ -142,12 +147,12 @@ func main() {
 
 	var mountPath string
 	switch config.AuthMethod {
-	case cfg.K8s:
+	case cfg.AuthMethodK8s:
 		auth.InferK8SConfig(&config)
 		mountPath = config.K8SAuthMount
-	case cfg.AWS:
+	case cfg.AuthMethodAWS:
 		mountPath = config.AWSAuthMount
-	case cfg.GCP:
+	case cfg.AuthMethodGCP:
 		mountPath = config.GCPAuthMount
 	}
 

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -48,27 +48,12 @@ const (
 )
 
 func init() {
+	flag.StringVar(&config.AuthMethod, "auth", "", "Set the vault authentication mechanism. Options are K8s, AWS, GCP")
 	flag.StringVar(&config.VaultAddress, "address", "", "Sets the vault server address. The default vault address or VAULT_ADDR environment variable is used if this is not supplied")
-	flag.StringVar(&config.TokenPath, "token-path", cfg.BuildDefaultConfigItem("TOKEN_PATH", "~/.vault-token"), "A full file path where a token will be read from/written to (env: TOKEN_PATH)")
-	flag.BoolVar(&config.K8SAuth, flagK8SAuth, func() bool {
-		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("K8S_AUTH", "false"))
-		return err == nil && b
-	}(), "Select kubernetes vault auth as the vault authentication mechanism (env: K8S_AUTH)")
-	flag.BoolVar(&config.AWSAuth, flagAWSIAMAuth, func() bool {
-		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("IAM_AUTH", "false"))
-		return err == nil && b
-	}(), "Select AWS IAM vault auth as the vault authentication mechanism (env: IAM_AUTH)")
-	flag.BoolVar(&config.AWSAuth, "iam-auth", func() bool {
-		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("IAM_AUTH", "false"))
-		return err == nil && b
-	}(), "(Legacy) Select AWS IAM vault auth as the vault authentication mechanism (env: IAM_AUTH)")
-	flag.StringVar(&config.K8STokenPath, "k8s-token-path", cfg.BuildDefaultConfigItem("K8S_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"), "Kubernetes service account JWT token path (env: K8S_TOKEN_PATH)")
-	flag.StringVar(&config.VaultAuthRoleName, "vault-auth-role", cfg.BuildDefaultConfigItem("VAULT_AUTH_ROLE", ""), "The name of the role used for auth. Used with either auth method (env: VAULT_AUTH_ROLE, note: will infer to k8s SA account name if left blank)")
-	flag.BoolVar(&config.GCPAuth, flagGCPAuth, func() bool {
-		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("GCP_AUTH", "false"))
-		return err == nil && b
-	}(), "Select Google Cloud Platform IAM auth as the vault authentication mechanism (env: GCP_AUTH)")
-	flag.StringVar(&config.GCPServiceAccount, "gcp-svc-acct", cfg.BuildDefaultConfigItem("GCP_SVC_ACCT", ""), "The name of the service account authenticating (env: GCP_SVC_ACCT)")
+	flag.StringVar(&config.TokenPath, "token-path", cfg.BuildDefaultConfigItem("TOKEN_PATH", "~/.vault-token"), "a full file path where a token will be read from/written to (env: TOKEN_PATH)")
+	flag.StringVar(&config.K8STokenPath, "k8s-token-path", cfg.BuildDefaultConfigItem("K8S_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"), "kubernetes service account jtw token path (env: K8S_TOKEN_PATH)")
+	flag.StringVar(&config.VaultAuthRoleName, "vault-auth-role", cfg.BuildDefaultConfigItem("VAULT_AUTH_ROLE", ""), "the name of the role used for auth. used with either auth method (env: VAULT_AUTH_ROLE, note: will infer to k8s sa account name if left blank)")
+	flag.StringVar(&config.GCPServiceAccount, "gcp-svc-acct", cfg.BuildDefaultConfigItem("GCP_SVC_ACCT", ""), "the name of the service account authenticating (env: GCP_SVC_ACCT)")
 	flag.Int64Var(&config.RenewalInterval, "renewal-interval", func() int64 {
 		b, err := strconv.ParseInt(cfg.BuildDefaultConfigItem("RENEWAL_INTERVAL", "300"), 10, 64)
 		if err != nil {
@@ -156,13 +141,13 @@ func main() {
 	}
 
 	var mountPath string
-	switch {
-	case config.K8SAuth:
+	switch config.AuthMethod {
+	case "K8S":
 		auth.InferK8SConfig(&config)
 		mountPath = config.K8SAuthMount
-	case config.AWSAuth:
+	case "AWS":
 		mountPath = config.AWSAuthMount
-	case config.GCPAuth:
+	case "GCP":
 		mountPath = config.GCPAuthMount
 	}
 

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -142,12 +142,12 @@ func main() {
 
 	var mountPath string
 	switch config.AuthMethod {
-	case "K8S":
+	case cfg.K8s:
 		auth.InferK8SConfig(&config)
 		mountPath = config.K8SAuthMount
-	case "AWS":
+	case cfg.AWS:
 		mountPath = config.AWSAuthMount
-	case "GCP":
+	case cfg.GCP:
 		mountPath = config.GCPAuthMount
 	}
 

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -49,11 +49,7 @@ const (
 )
 
 func init() {
-	flag.Func("auth-method", "Select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH_METHOD)", func(authMethod string) error {
-		upperAuthMethod := strings.ToUpper(authMethod)
-		config.AuthMethod = cfg.AuthMethod(upperAuthMethod)
-		return nil
-	})
+	flag.Var(&config.AuthMethod, "auth-method", "Select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH_METHOD)")
 	flag.StringVar(&config.VaultAddress, "address", "", "Sets the vault server address. The default vault address or VAULT_ADDR environment variable is used if this is not supplied")
 	flag.StringVar(&config.TokenPath, "token-path", cfg.BuildDefaultConfigItem("TOKEN_PATH", "~/.vault-token"), "a full file path where a token will be read from/written to (env: TOKEN_PATH)")
 	flag.StringVar(&config.K8STokenPath, "k8s-token-path", cfg.BuildDefaultConfigItem("K8S_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"), "kubernetes service account jtw token path (env: K8S_TOKEN_PATH)")

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -43,9 +43,8 @@ var version string
 
 func init() {
 	flag.Var(&config.AuthMethod, "auth-method", "Select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH_METHOD)")
-	flag.StringVar(&config.AuthMount, "auth-mount", "", "The vault mount where auth takes place")
-	flag.StringVar(&config.FullAuthMount, "full-auth-mount", "", "The complete path for auth. If not provied one will be constructed from -auth-mount")
-
+	flag.StringVar(&config.AuthMount, "auth-mount", cfg.BuildDefaultConfigItem("AUTH_MOUNT", ""), "The vault mount where auth takes place (env: AUTH_MOUNT)")
+	flag.StringVar(&config.AuthPath, "auth-path", cfg.BuildDefaultConfigItem("AUTH_PATH", ""), "The complete path for auth. If not provied one will be constructed from -auth-mount")
 	flag.StringVar(&config.VaultAddress, "address", "", "Sets the vault server address. The default vault address or VAULT_ADDR environment variable is used if this is not supplied")
 	flag.StringVar(&config.TokenPath, "token-path", cfg.BuildDefaultConfigItem("TOKEN_PATH", "~/.vault-token"), "a full file path where a token will be read from/written to (env: TOKEN_PATH)")
 	flag.StringVar(&config.K8STokenPath, "k8s-token-path", cfg.BuildDefaultConfigItem("K8S_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"), "kubernetes service account jtw token path (env: K8S_TOKEN_PATH)")

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -48,7 +48,7 @@ const (
 )
 
 func init() {
-	flag.StringVar(&config.AuthMethod, "auth", "", "Set the vault authentication mechanism. Options are K8s, AWS, GCP")
+	flag.StringVar(&config.AuthMethod, "auth-method", "", "Select between AWS, GCP, or K8S as the vault authentication mechanism (env: AUTH_METHOD)")
 	flag.StringVar(&config.VaultAddress, "address", "", "Sets the vault server address. The default vault address or VAULT_ADDR environment variable is used if this is not supplied")
 	flag.StringVar(&config.TokenPath, "token-path", cfg.BuildDefaultConfigItem("TOKEN_PATH", "~/.vault-token"), "a full file path where a token will be read from/written to (env: TOKEN_PATH)")
 	flag.StringVar(&config.K8STokenPath, "k8s-token-path", cfg.BuildDefaultConfigItem("K8S_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"), "kubernetes service account jtw token path (env: K8S_TOKEN_PATH)")

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -129,7 +129,7 @@ func main() {
 	log.Info().Str("version", version).Msg("Starting...")
 
 	if !config.ValidateAuthType() {
-		log.Fatal().Strs("authMethods", []string{string(cfg.AuthMethodK8s), string(cfg.AuthMethodAWS), string(cfg.AuthMethodGCP)}).Msg("You must provide an auth method")
+		log.Fatal().Strs("authMethods", auth.Authenticators.Available()).Msg("You must provide an auth method")
 	}
 
 	if err := config.ValidateConfig(); err != nil {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -62,7 +62,7 @@ func authenticate(client *api.Client, config cfg.Config, svc Authenticator) bool
 }
 
 func fetchVaultToken(client *api.Client, config cfg.Config, loginData map[string]interface{}) (string, error) {
-	secret, err := client.Logical().Write(config.FullAuthMount, loginData)
+	secret, err := client.Logical().Write(config.AuthPath, loginData)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -105,11 +105,11 @@ func EnsureAuthenticated(client *api.Client, config cfg.Config) bool {
 
 	var svc Authenticator
 	switch config.AuthMethod {
-	case cfg.K8s:
+	case cfg.AuthMethodK8s:
 		svc = &K8SService{}
-	case cfg.AWS:
+	case cfg.AuthMethodAWS:
 		svc = &AWSService{}
-	case cfg.GCP:
+	case cfg.AuthMethodGCP:
 		svc = &GCPService{}
 	default:
 		panic("should never get here")

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -104,12 +104,12 @@ func EnsureAuthenticated(client *api.Client, config cfg.Config) bool {
 	}
 
 	var svc Authenticator
-	switch {
-	case config.K8SAuth:
+	switch config.AuthMethod {
+	case "K8S":
 		svc = &K8SService{}
-	case config.AWSAuth:
+	case "AWS":
 		svc = &AWSService{}
-	case config.GCPAuth:
+	case "GCP":
 		svc = &GCPService{}
 	default:
 		panic("should never get here")

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -62,7 +62,7 @@ func authenticate(client *api.Client, config cfg.Config, svc Authenticator) bool
 }
 
 func fetchVaultToken(client *api.Client, config cfg.Config, loginData map[string]interface{}) (string, error) {
-	secret, err := client.Logical().Write(config.AuthMount, loginData)
+	secret, err := client.Logical().Write(config.FullAuthMount, loginData)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -35,6 +35,24 @@ type Authenticator interface {
 	Auth(*api.Client, cfg.Config) (string, error)
 }
 
+var Authenticators RegisteredAuthenticators = map[cfg.AuthMethod]Authenticator{
+	cfg.AuthMethodK8s: &K8SService{},
+	cfg.AuthMethodAWS: &AWSService{},
+	cfg.AuthMethodGCP: &GCPService{},
+}
+
+type RegisteredAuthenticators map[cfg.AuthMethod]Authenticator
+
+func (ra RegisteredAuthenticators) Available() []string {
+	available := make([]string, 0, len(ra))
+
+	for authenticator := range ra {
+		available = append(available, string(authenticator))
+	}
+
+	return available
+}
+
 // authenticate authenticates with Vault, returns true if successful
 func authenticate(client *api.Client, config cfg.Config, svc Authenticator) bool {
 	var vaultToken string
@@ -103,17 +121,11 @@ func EnsureAuthenticated(client *api.Client, config cfg.Config) bool {
 		bo.MaxElapsedTime = time.Second * time.Duration(config.MaximumAuthRetry)
 	}
 
-	var svc Authenticator
-	switch config.AuthMethod {
-	case cfg.AuthMethodK8s:
-		svc = &K8SService{}
-	case cfg.AuthMethodAWS:
-		svc = &AWSService{}
-	case cfg.AuthMethodGCP:
-		svc = &GCPService{}
-	default:
-		panic("should never get here")
-	}
+	svc, ok := Authenticators[config.AuthMethod] 
+	if !ok {
+		log.Error().Strs("authMethods", Authenticators.Available()).Msg("You must provide a valid auth method")
+		return false
+	} 
 
 	authTicker := backoff.NewTicker(bo)
 	for range authTicker.C {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -121,11 +121,11 @@ func EnsureAuthenticated(client *api.Client, config cfg.Config) bool {
 		bo.MaxElapsedTime = time.Second * time.Duration(config.MaximumAuthRetry)
 	}
 
-	svc, ok := Authenticators[config.AuthMethod] 
+	svc, ok := Authenticators[config.AuthMethod]
 	if !ok {
 		log.Error().Strs("authMethods", Authenticators.Available()).Msg("You must provide a valid auth method")
 		return false
-	} 
+	}
 
 	authTicker := backoff.NewTicker(bo)
 	for range authTicker.C {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -105,11 +105,11 @@ func EnsureAuthenticated(client *api.Client, config cfg.Config) bool {
 
 	var svc Authenticator
 	switch config.AuthMethod {
-	case "K8S":
+	case cfg.K8s:
 		svc = &K8SService{}
-	case "AWS":
+	case cfg.AWS:
 		svc = &AWSService{}
-	case "GCP":
+	case cfg.GCP:
 		svc = &GCPService{}
 	default:
 		panic("should never get here")

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -86,7 +86,7 @@ const (
 `
 )
 
-func TestAuthPanic(t *testing.T) {
+func TestInvalidAuthMethod(t *testing.T) {
 	var config cfg.Config
 	client, err := testhelpers.GetTestClient("nan")
 	if err != nil {
@@ -94,7 +94,7 @@ func TestAuthPanic(t *testing.T) {
 	}
 	client.SetToken(testToken)
 	config.MaximumAuthRetry = 1
-	assert.Panics(t, func() { EnsureAuthenticated(client, config) }, "The code did not panic when it should have")
+	assert.False(t, EnsureAuthenticated(client, config) , "The code did not return false when it should have")
 }
 
 type MockedService struct {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -94,7 +94,7 @@ func TestInvalidAuthMethod(t *testing.T) {
 	}
 	client.SetToken(testToken)
 	config.MaximumAuthRetry = 1
-	assert.False(t, EnsureAuthenticated(client, config) , "The code did not return false when it should have")
+	assert.False(t, EnsureAuthenticated(client, config), "The code did not return false when it should have")
 }
 
 type MockedService struct {

--- a/pkg/auth/k8s.go
+++ b/pkg/auth/k8s.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+
 // K8SService is an external service that vault can authenticate requests against
 type K8SService struct{}
 
@@ -63,7 +64,7 @@ func InferK8SConfig(config *cfg.Config) {
 	}
 
 	// Check for default value
-	if config.AuthMount == "kubernetes" {
+	if config.AuthMount == cfg.DefaultK8sAuthMount {
 		vaultAuthMount, err := inferVaultAuthMount()
 		if err != nil {
 			log.Warn().Err(err).Msg("Unable to infer K8S Vault Auth Mount")

--- a/pkg/auth/k8s.go
+++ b/pkg/auth/k8s.go
@@ -28,7 +28,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-
 // K8SService is an external service that vault can authenticate requests against
 type K8SService struct{}
 

--- a/pkg/auth/k8s.go
+++ b/pkg/auth/k8s.go
@@ -63,12 +63,12 @@ func InferK8SConfig(config *cfg.Config) {
 	}
 
 	// Check for default value
-	if config.K8SAuthMount == "kubernetes" {
+	if config.AuthMount == "kubernetes" {
 		vaultAuthMount, err := inferVaultAuthMount()
 		if err != nil {
 			log.Warn().Err(err).Msg("Unable to infer K8S Vault Auth Mount")
 		} else {
-			config.K8SAuthMount = vaultAuthMount
+			config.AuthMount = vaultAuthMount
 		}
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,11 +4,22 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cruise-automation/daytona/pkg/logging"
 )
 
 type AuthMethod string
+
+func (a *AuthMethod) String() string {
+	return string(*a)
+}
+
+func (a *AuthMethod) Set(value string) error {
+	upperAuthMethod := strings.ToUpper(value)
+	*a = AuthMethod(upperAuthMethod)
+	return nil
+}
 
 // Auth methods
 const (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,12 @@ const (
 	AuthMethodGCP AuthMethod = "GCP"
 )
 
+const (
+	DefaultK8sAuthMount = "kubernetes"
+	DefaultAWSAuthMount = "aws"
+	DefaultGCPAuthMount = "gcp"
+)
+
 const authPathFmtString = "auth/%s/login"
 
 // Config represents an application configuration
@@ -88,11 +94,11 @@ func (c *Config) ValidateAuthType() bool {
 	if c.AuthMount == "" {
 		switch c.AuthMethod {
 		case AuthMethodK8s:
-			c.AuthMount = "kubernetes"
+			c.AuthMount = DefaultK8sAuthMount
 		case AuthMethodAWS:
-			c.AuthMount = "aws"
+			c.AuthMount = DefaultAWSAuthMount
 		case AuthMethodGCP:
-			c.AuthMount = "gcp"
+			c.AuthMount = DefaultGCPAuthMount
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,16 +4,17 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/cruise-automation/daytona/pkg/logging"
 )
 
+type AuthMethod string
+
 // Auth methods
 const (
-	K8s = "K8S"
-	AWS = "AWS"
-	GCP = "GCP"
+	AuthMethodK8s AuthMethod = "K8S"
+	AuthMethodAWS AuthMethod = "AWS"
+	AuthMethodGCP AuthMethod = "GCP"
 )
 
 const authPathFmtString = "auth/%s/login"
@@ -22,7 +23,7 @@ const authPathFmtString = "auth/%s/login"
 type Config struct {
 	VaultAddress      string
 	TokenPath         string
-	AuthMethod        string
+	AuthMethod        AuthMethod
 	K8STokenPath      string
 	K8SAuthMount      string
 	AWSAuthMount      string
@@ -61,10 +62,8 @@ func BuildDefaultConfigItem(envKey string, def string) (val string) {
 // ValidateAuthType validates that the user has supplied
 // a valid authentication type
 func (c *Config) ValidateAuthType() bool {
-	c.AuthMethod = strings.ToUpper(c.AuthMethod)
-
 	switch c.AuthMethod {
-	case K8s, AWS, GCP:
+	case AuthMethodK8s, AuthMethodAWS, AuthMethodGCP:
 		return true
 	default:
 		return false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cruise-automation/daytona/pkg/logging"
 )
@@ -14,12 +15,10 @@ const authPathFmtString = "auth/%s/login"
 type Config struct {
 	VaultAddress      string
 	TokenPath         string
+	AuthMethod        string
 	K8STokenPath      string
-	K8SAuth           bool
 	K8SAuthMount      string
-	AWSAuth           bool
 	AWSAuthMount      string
-	GCPAuth           bool
 	GCPAuthMount      string
 	GCPServiceAccount string
 	VaultAuthRoleName string
@@ -55,16 +54,14 @@ func BuildDefaultConfigItem(envKey string, def string) (val string) {
 // ValidateAuthType validates that the user has supplied
 // a valid authentication type
 func (c *Config) ValidateAuthType() bool {
-	p := 0
-	for _, v := range []bool{c.K8SAuth, c.AWSAuth, c.GCPAuth} {
-		if v {
-			p++
-		}
-	}
-	if p == 0 || p > 1 {
+	c.AuthMethod = strings.ToUpper(c.AuthMethod)
+
+	switch c.AuthMethod {
+	case "k8S", "AWS", "GCP":
+		return true
+	default:
 		return false
 	}
-	return true
 }
 
 // ValidateConfig attempts to perform some generic

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	TokenPath         string
 	AuthMethod        AuthMethod
 	AuthMount         string
-	FullAuthMount     string
+	AuthPath          string
 	K8STokenPath      string
 	GCPServiceAccount string
 	VaultAuthRoleName string
@@ -71,6 +71,12 @@ func BuildDefaultConfigItem(envKey string, def string) (val string) {
 // ValidateAuthType validates that the user has supplied
 // a valid authentication type
 func (c *Config) ValidateAuthType() bool {
+
+	if c.AuthMethod == "" {
+		val := os.Getenv("AUTH_METHOD")
+		c.AuthMethod.Set(val)
+	}
+
 	switch c.AuthMethod {
 	case AuthMethodK8s, AuthMethodAWS, AuthMethodGCP:
 		break
@@ -90,8 +96,8 @@ func (c *Config) ValidateAuthType() bool {
 		}
 	}
 
-	if c.FullAuthMount == "" {
-		c.FullAuthMount = fmt.Sprintf(authPathFmtString, c.AuthMount)
+	if c.AuthPath == "" {
+		c.AuthPath = fmt.Sprintf(authPathFmtString, c.AuthMount)
 	}
 
 	return true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,13 @@ import (
 	"github.com/cruise-automation/daytona/pkg/logging"
 )
 
+// Auth methods
+const (
+	K8s = "K8S"
+	AWS = "AWS"
+	GCP = "GCP"
+)
+
 const authPathFmtString = "auth/%s/login"
 
 // Config represents an application configuration
@@ -57,7 +64,7 @@ func (c *Config) ValidateAuthType() bool {
 	c.AuthMethod = strings.ToUpper(c.AuthMethod)
 
 	switch c.AuthMethod {
-	case "k8S", "AWS", "GCP":
+	case K8s, AWS, GCP:
 		return true
 	default:
 		return false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"flag"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,44 +45,60 @@ func TestInvalidConfig(t *testing.T) {
 
 func TestValidateAuthType(t *testing.T) {
 	var config Config
-	config.AuthMethod = "UNKNOWN"
+
+	// If not set try to pull from env
+	os.Setenv("AUTH_METHOD", "k8s")
 	ok := config.ValidateAuthType()
+	assert.True(t, ok, "expected auth type to be valid")
+	assert.Equal(t, "auth/kubernetes/login", config.AuthPath)
+
+	os.Setenv("AUTH_METHOD", "unknown")
+	config.AuthMethod = ""
+	config.AuthMount = ""
+	config.AuthPath = ""
+	ok = config.ValidateAuthType()
+	assert.False(t, ok, "expected auth type to be invalid")
+
+	config.AuthMethod = "UNKNOWN"
+	config.AuthMount = ""
+	config.AuthPath = ""
+	ok = config.ValidateAuthType()
 	assert.False(t, ok, "expected auth type to be invalid")
 
 	config.AuthMethod = "K8S"
 	config.AuthMount = ""
-	config.FullAuthMount = ""
+	config.AuthPath = ""
 	ok = config.ValidateAuthType()
 	assert.True(t, ok, "expected auth type to be valid")
-	assert.Equal(t, "auth/kubernetes/login", config.FullAuthMount)
+	assert.Equal(t, "auth/kubernetes/login", config.AuthPath)
 
 	config.AuthMethod = "AWS"
 	config.AuthMount = ""
-	config.FullAuthMount = ""
+	config.AuthPath = ""
 	ok = config.ValidateAuthType()
 	assert.True(t, ok, "expected auth type to be valid")
-	assert.Equal(t, "auth/aws/login", config.FullAuthMount)
+	assert.Equal(t, "auth/aws/login", config.AuthPath)
 
 	config.AuthMethod = "GCP"
 	config.AuthMount = ""
-	config.FullAuthMount = ""
+	config.AuthPath = ""
 	ok = config.ValidateAuthType()
 	assert.True(t, ok, "expected auth type to be valid")
-	assert.Equal(t, "auth/gcp/login", config.FullAuthMount)
+	assert.Equal(t, "auth/gcp/login", config.AuthPath)
 
 	config.AuthMethod = "K8S"
 	config.AuthMount = "is-set"
-	config.FullAuthMount = ""
+	config.AuthPath = ""
 	ok = config.ValidateAuthType()
 	assert.True(t, ok, "expected auth type to be valid")
-	assert.Equal(t, "auth/is-set/login", config.FullAuthMount)
+	assert.Equal(t, "auth/is-set/login", config.AuthPath)
 
 	config.AuthMethod = "K8S"
 	config.AuthMount = ""
-	config.FullAuthMount = "is-set"
+	config.AuthPath = "is-set"
 	ok = config.ValidateAuthType()
 	assert.True(t, ok, "expected auth type to be valid")
-	assert.Equal(t, "is-set", config.FullAuthMount)
+	assert.Equal(t, "is-set", config.AuthPath)
 }
 
 func TestAuthMethodParse(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -47,8 +47,7 @@ func TestValidateAuthType(t *testing.T) {
 	ok := config.ValidateAuthType()
 	assert.False(t, ok, "expected auth type to be invalid")
 
-	config.AuthMethod = "k8s"
+	config.AuthMethod = "K8S"
 	ok = config.ValidateAuthType()
 	assert.True(t, ok, "expected auth type to be valid")
-	assert.Equal(t, "K8S", config.AuthMethod, "expected auth type to have been uppercased")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -49,8 +49,39 @@ func TestValidateAuthType(t *testing.T) {
 	assert.False(t, ok, "expected auth type to be invalid")
 
 	config.AuthMethod = "K8S"
+	config.AuthMount = ""
+	config.FullAuthMount = ""
 	ok = config.ValidateAuthType()
 	assert.True(t, ok, "expected auth type to be valid")
+	assert.Equal(t, "auth/kubernetes/login", config.FullAuthMount)
+
+	config.AuthMethod = "AWS"
+	config.AuthMount = ""
+	config.FullAuthMount = ""
+	ok = config.ValidateAuthType()
+	assert.True(t, ok, "expected auth type to be valid")
+	assert.Equal(t, "auth/aws/login", config.FullAuthMount)
+
+	config.AuthMethod = "GCP"
+	config.AuthMount = ""
+	config.FullAuthMount = ""
+	ok = config.ValidateAuthType()
+	assert.True(t, ok, "expected auth type to be valid")
+	assert.Equal(t, "auth/gcp/login", config.FullAuthMount)
+
+	config.AuthMethod = "K8S"
+	config.AuthMount = "is-set"
+	config.FullAuthMount = ""
+	ok = config.ValidateAuthType()
+	assert.True(t, ok, "expected auth type to be valid")
+	assert.Equal(t, "auth/is-set/login", config.FullAuthMount)
+
+	config.AuthMethod = "K8S"
+	config.AuthMount = ""
+	config.FullAuthMount = "is-set"
+	ok = config.ValidateAuthType()
+	assert.True(t, ok, "expected auth type to be valid")
+	assert.Equal(t, "is-set", config.FullAuthMount)
 }
 
 func TestAuthMethodParse(t *testing.T) {
@@ -60,11 +91,11 @@ func TestAuthMethodParse(t *testing.T) {
 	f.Var(authMethod, "auth-method", "test")
 	args := []string{
 		"-auth-method",
-		"lowerCase",
+		"testAuth",
 	}
 
 	err := f.Parse(args)
 	assert.NoError(t, err)
 	assert.True(t, f.Parsed(), "f.Parse() = false after Parse")
-	assert.Equal(t, "LOWERCASE", authMethod.String())
+	assert.Equal(t, "TESTAUTH", authMethod.String())
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,17 +45,10 @@ func TestValidateAuthType(t *testing.T) {
 	var config Config
 	config.AuthMethod = "UNKNOWN"
 	ok := config.ValidateAuthType()
-	if ok {
-		t.Fatal("expected auth type to be valid invalid")
-	}
+	assert.False(t, ok, "expected auth type to be invalid")
 
 	config.AuthMethod = "k8s"
 	ok = config.ValidateAuthType()
-	if ok {
-		t.Fatal("expected auth type to be valid")
-	}
-
-	if config.AuthMethod != "K8S" {
-		t.Fatal("expected auth type to have been uppercased")
-	}
+	assert.True(t, ok, "expected auth type to be valid")
+	assert.Equal(t, "K8S", config.AuthMethod, "expected auth type to have been uppercased")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,4 +51,20 @@ func TestValidateAuthType(t *testing.T) {
 	config.AuthMethod = "K8S"
 	ok = config.ValidateAuthType()
 	assert.True(t, ok, "expected auth type to be valid")
+}
+
+func TestAuthMethodParse(t *testing.T) {
+	authMethod := new(AuthMethod)
+	f := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	f.Var(authMethod, "auth-method", "test")
+	args := []string{
+		"-auth-method",
+		"lowerCase",
+	}
+
+	err := f.Parse(args)
+	assert.NoError(t, err)
+	assert.True(t, f.Parsed(), "f.Parse() = false after Parse")
+	assert.Equal(t, "LOWERCASE", authMethod.String())
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,23 +7,19 @@ import (
 )
 
 func (c *Config) GenerateStandardTestConfig() {
-	c.K8SAuth = true
+	c.AuthMethod = "K8S"
 	c.MaximumAuthRetry = 1
 }
 
 func TestInvalidConfig(t *testing.T) {
 	var config Config
-	config.K8SAuth = true
-	config.AWSAuth = true
-	config.GCPAuth = false
+	config.AuthMethod = "UNKNOWN"
 	err := config.ValidateConfig()
 	if err == nil {
 		t.Fatal("expected an error from invalid config")
 	}
 
-	config.K8SAuth = true
-	config.AWSAuth = false
-	config.GCPAuth = false
+	config.AuthMethod = "K8S"
 	err = config.ValidateConfig()
 	assert.Equal(t, "you must supply a role name via VAULT_AUTH_ROLE or -vault-auth-role", err.Error())
 
@@ -42,5 +38,24 @@ func TestInvalidConfig(t *testing.T) {
 	err = config.ValidateConfig()
 	if err != nil {
 		t.Fatal("got an error in PKI config, didn't expect one, bailing")
+	}
+}
+
+func TestValidateAuthType(t *testing.T) {
+	var config Config
+	config.AuthMethod = "UNKNOWN"
+	ok := config.ValidateAuthType()
+	if ok {
+		t.Fatal("expected auth type to be valid invalid")
+	}
+
+	config.AuthMethod = "k8s"
+	ok = config.ValidateAuthType()
+	if ok {
+		t.Fatal("expected auth type to be valid")
+	}
+
+	if config.AuthMethod != "K8S" {
+		t.Fatal("expected auth type to have been uppercased")
 	}
 }


### PR DESCRIPTION
Right now each auth method has its own flag: `--k8s-auth`, `--aws-auth`, etc.

 
This doesn't scale and we should migrate to an input method: `--auth-method` that takes an input for which type of auth to do (k8s/aws/gcp/azure, etc.)

Also  move `{gcp,k8s,aws}-auth-mount` to `auth-mount` and move the existing `auth-mount` to `auth-path`,  Where `auth-mount`is used to generate a `auth-path` if not provided.  The defaults for `auth-mount` and `auth-path` are handled during the validation of the `auth-method`

**This is a breaking change of the API.**