### PR TITLE
Add Azure Auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0 - August 31, 2021
+
+- Add Azure Auth method (#78)
+
 ## 1.1.6 - May 10, 2021
 
 - Address a defect with the parsing & handling of alt_names (#76)

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ as a representation of the following vault data:
 
 **Azure IAM Example - Writing to a File**:
 
-Assume you have the following Vault Azure Auth Role, `vault-role-name`:
+Assume you have the following [Vault Azure Auth Role](https://www.vaultproject.io/api/auth/azure#create-role), `vault-role-name`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The following authentication methods are supported:
 
  - **GCP IAM** - To be used with the [Vault GCP Auth Backend](https://www.vaultproject.io/docs/auth/gcp.html). Uses GCP service accounts for IAM Vault authentication. Intended for use with GCP resources that utilize bound service accounts.
 
+ - **Azure IAM** - To be used with the [Vault Azure Auth Backend](https://www.vaultproject.io/docs/auth/azure.html). Uses Azure Active Directory credentials for IAM Vault authentication. Intended for use with Azure resources that utilize manged identities.
+
 ----
 
 ## Secret Fetching
@@ -473,6 +475,45 @@ as a representation of the following vault data:
 ```
 
 **Security Consideration** - When using the GCP IAM Auth type, ensure that the capability for the GCP SA to use the `signjwt` permission is limited only to the service accounts you wish to authenticate with to Vault. Providing your GCP SA the `signjwt` permission, such as through `iam.serviceAccountTokenCreator`, when done at the project level will over-authorize your service account to be able to sign JWTs of any other service account in the project, thus impersonating them. It is best practice to bind these permissions against the service account itself, and not at the project level. For more information, see the [GCP Documentation](https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource) on how to grant permissions against a specific service account.
+
+**Azure IAM Example - Writing to a File**:
+
+Assume you have the following Vault Azure Auth Role, `vault-role-name`:
+
+```json
+{
+  "bound_subscription_ids": [
+     "00000000-0000-0000-0000-000000000000"
+  ],
+  "token_policies": [
+    "my-ro-policy"
+  ]
+}
+```
+
+```
+VAULT_SECRETS_TEST=secret/path/to/app/secrets DAYTONA_SECRET_DESTINATION_TEST=/home/vault/secrets daytona -azure-auth -token-path /home/vault/.vault-token -vault-auth-role vault-role-name
+```
+
+The execution example above (assuming a successful authentication) would yield a vault token at `/home/vault/.vault-token` and any specified secrets written to `/home/vault/secrets` as
+
+```json
+{
+  "secrets_secretA": "hellooo",
+  "secrets_api_key": "supersecret"
+}
+```
+
+as a representation of the following vault data:
+
+`secret/path/to/app/secrets`
+
+```
+{
+  "secretA": "hellooo",
+  "api_key": "supersecret"
+}
+```
 
 Development
 -----------

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -45,6 +45,7 @@ const (
 	flagAWSIAMAuth = "aws-auth"
 	flagK8SAuth    = "k8s-auth"
 	flagGCPAuth    = "gcp-auth"
+	flagAzureAuth  = "azure-auth"
 )
 
 func init() {
@@ -144,6 +145,12 @@ func init() {
 		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("LOG_STRUCTURED", "true"))
 		return err == nil && b
 	}(), "If set, log output will be JSON else writes human-friendly format (env: LOG_STRUCTURED)")
+
+	flag.StringVar(&config.AzureAuthMount, "azure-auth-mount", cfg.BuildDefaultConfigItem("AZURE_AUTH_MOUNT", "azure"), "the vault mount where azure auth takes place (env: AZURE_AUTH_MOUNT)")
+	flag.BoolVar(&config.AzureAuth, flagAzureAuth, func() bool {
+		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("AZURE_AUTH", "false"))
+		return err == nil && b
+	}(), "select Azure IAM auth as the vault authentication mechanism (env: AZURE_AUTH)")
 }
 
 func main() {
@@ -164,6 +171,8 @@ func main() {
 		mountPath = config.AWSAuthMount
 	case config.GCPAuth:
 		mountPath = config.GCPAuthMount
+	case config.AzureAuth:
+		mountPath = config.AzureAuthMount
 	}
 
 	// =========================================================================

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -112,7 +112,7 @@ func EnsureAuthenticated(client *api.Client, config cfg.Config) bool {
 	case config.GCPAuth:
 		svc = &GCPService{}
 	case config.AzureAuth:
-		svc = &AWSService{}
+		svc = &AzureService{}
 	default:
 		panic("should never get here")
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -111,6 +111,8 @@ func EnsureAuthenticated(client *api.Client, config cfg.Config) bool {
 		svc = &AWSService{}
 	case config.GCPAuth:
 		svc = &GCPService{}
+	case config.AzureAuth:
+		svc = &AWSService{}
 	default:
 		panic("should never get here")
 	}

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019-present, Cruise LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	cfg "github.com/cruise-automation/daytona/pkg/config"
+	"github.com/hashicorp/vault/api"
+)
+
+// AzureService is an external service that vault can authenticate request against
+type AzureService struct{}
+
+func (a *AzureService) Auth(client *api.Client, config cfg.Config) (string, error) {
+}
+
+type azureVaultPayload struct {
+	Role              string
+	SubscriptionID    string
+	VmName            string
+	ResourceGroupName string
+	JWT               string
+}
+
+type simplifiedMetadata struct {
+	Compute simplifiedCompute `json:"compute"`
+}
+type simplifiedCompute struct {
+	Name              string `json:"name"`
+	ResourceGroupName string `json:"resourceGroupName"`
+	SubscriptionID    string `json:"subscriptionId"`
+}
+
+func (a *AWSService) getJWT()(string, error) {
+	// response=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' -H Metadata:true -s)
+	jwt 
+}
+
+func (a *AWSService) getMetadata(baseURL string) (*simplifiedMetadata, error) {
+	// Get metadata
+	// Metadata is not exposed through the Azure-sdk-for-go https://github.com/Azure/azure-sdk-for-go/issues/982
+	// metadata=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01")
+	metadataEndpoint := fmt.Sprintf("%s/metadata/instance?api-version=2017-08-01", baseURL)
+	r, err := http.NewRequest(http.MethodGet, metadataEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Header.Add("Metadata","true")
+
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := new(simplifiedMetadata)
+	err = json.NewDecoder(resp.Body).Decode(metadata)
+
+	return metadata, err 
+}

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -47,12 +47,35 @@ type simplifiedCompute struct {
 	SubscriptionID    string `json:"subscriptionId"`
 }
 
-func (a *AWSService) getJWT()(string, error) {
+type simplifiedToken struct {
+	AccessToken string `json:"access_token"`
+}
+
+func (a *AWSService) getJWT(baseURL string) (string, error) {
+	// TODO: build the request in parts
 	// response=$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' -H Metadata:true -s)
-	jwt 
+	jwtEndpoint := fmt.Sprintf("%s/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/", baseURL)
+	r, err := http.NewRequest(http.MethodGet, jwtEndpoint, nil)
+	if err != nil {
+		return "", err
+	}
+
+	r.Header.Add("Metadata", "true")
+
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return "", err
+	}
+
+	token := new(simplifiedToken)
+	err = json.NewDecoder(resp.Body).Decode(token)
+
+	return token.AccessToken, err
+
 }
 
 func (a *AWSService) getMetadata(baseURL string) (*simplifiedMetadata, error) {
+	// TODO: build the request in parts
 	// Get metadata
 	// Metadata is not exposed through the Azure-sdk-for-go https://github.com/Azure/azure-sdk-for-go/issues/982
 	// metadata=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01")
@@ -62,7 +85,7 @@ func (a *AWSService) getMetadata(baseURL string) (*simplifiedMetadata, error) {
 		return nil, err
 	}
 
-	r.Header.Add("Metadata","true")
+	r.Header.Add("Metadata", "true")
 
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
@@ -72,5 +95,5 @@ func (a *AWSService) getMetadata(baseURL string) (*simplifiedMetadata, error) {
 	metadata := new(simplifiedMetadata)
 	err = json.NewDecoder(resp.Body).Decode(metadata)
 
-	return metadata, err 
+	return metadata, err
 }

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -70,7 +70,6 @@ func (a *AzureService) getJWT() (string, error) {
 	r.Header.Add("Metadata", "true")
 
 	q := r.URL.Query()
-	q.Add("format", "json")
 	q.Add("api-version", "2018-02-01")
 	q.Add("resource", "https://management.azure.com/")
 	r.URL.RawQuery = q.Encode()
@@ -82,7 +81,7 @@ func (a *AzureService) getJWT() (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code while getting JWT %d", resp.StatusCode)
+		return "", fmt.Errorf("unexpected status code while getting JWT: %d", resp.StatusCode)
 	}
 
 	token := new(simplifiedToken)

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -17,6 +17,7 @@ package auth
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	cfg "github.com/cruise-automation/daytona/pkg/config"
@@ -70,15 +71,18 @@ func (a *AzureService) getJWT() (string, error) {
 
 	q := r.URL.Query()
 	q.Add("format", "json")
-	// TODO: look at updating the api-version
 	q.Add("api-version", "2018-02-01")
 	q.Add("resource", "https://management.azure.com/")
-
 	r.URL.RawQuery = q.Encode()
 
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
 		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code while getting JWT %d", resp.StatusCode)
 	}
 
 	token := new(simplifiedToken)
@@ -107,14 +111,17 @@ func (a *AzureService) getMetadata() (*simplifiedMetadata, error) {
 
 	q := r.URL.Query()
 	q.Add("format", "json")
-	// TODO: look at updating the api-version
 	q.Add("api-version", "2017-08-01")
-
 	r.URL.RawQuery = q.Encode()
 
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
 		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code while getting Metadata %d", resp.StatusCode)
 	}
 
 	metadata := new(simplifiedMetadata)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,7 +58,7 @@ func BuildDefaultConfigItem(envKey string, def string) (val string) {
 // a valid authentication type
 func (c *Config) ValidateAuthType() bool {
 	p := 0
-	for _, v := range []bool{c.K8SAuth, c.AWSAuth, c.GCPAuth, c.AWSAuth} {
+	for _, v := range []bool{c.K8SAuth, c.AWSAuth, c.GCPAuth, c.AzureAuth} {
 		if v {
 			p++
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,8 @@ type Config struct {
 	PkiCertificate    string
 	PkiUseCaChain     bool
 	Log               logging.Config
+	AzureAuth         bool
+	AzureAuthMount    string
 }
 
 // BuildDefaultConfigItem uses the following operation: ENV --> arg
@@ -56,7 +58,7 @@ func BuildDefaultConfigItem(envKey string, def string) (val string) {
 // a valid authentication type
 func (c *Config) ValidateAuthType() bool {
 	p := 0
-	for _, v := range []bool{c.K8SAuth, c.AWSAuth, c.GCPAuth} {
+	for _, v := range []bool{c.K8SAuth, c.AWSAuth, c.GCPAuth, c.AWSAuth} {
 		if v {
 			p++
 		}


### PR DESCRIPTION
fixes issue #65 

Creates a Auth request to an[ Azure Auth backend](https://www.vaultproject.io/docs/auth/azure).  It pulls instance metadata from the [Azure metadata endpoint](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux#instance-metadata) and a JWT from the [Managed Identities endpoint](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-go)

To use the Azure Auth  set `--azure-auth=true` flag or the environment variable `AZURE_AUTH=true`. An optional `--azure-auth-mount` or `AZURE_AUTH_MOUNT` can be used to configure what Azure Auth backend is used, the default is `azure`.