### PR TITLE
Set DAYTONA/<version> as the User-Agent instead of the default Go http UA.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1 - September 22, 2021
+
+- Set DAYTONA/<version> as the User-Agent instead of the default Go http UA. (#80)
+
 ## 1.2.0 - August 31, 2021
 
 - Add Azure Auth method (#78)

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -38,8 +38,13 @@ import (
 
 var config cfg.Config
 
-// this is populated at build time
-var version string
+var (
+	// this is populated at build time
+	version string
+
+	// HTTPUserAgent is the header used to identify this application.
+	httpUserAgent = "DAYTONA/" + version
+)
 
 const (
 	flagAWSIAMAuth = "aws-auth"
@@ -219,6 +224,8 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Could not configure vault client. Exiting.")
 	}
+
+	client.AddHeader("User-Agent", httpUserAgent)
 
 	if !auth.EnsureAuthenticated(client, config) {
 		log.Fatal().Msg("The maximum elapsed time has been reached for authentication attempts. Exiting.")


### PR DESCRIPTION
This PR updates Daytona to use a custom HTTP User-Agent, instead of the default Go `http` module UA (`Go-http-client/2.0"`).