### PR TITLE
Improve logging output to be more informative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.2.3 - UNRELEASED
 
-- Update to go 1.18.3
+- Update to go 1.18.3 (#87)
 - Update k8s role name inferring logic to support both pre and post version 1.21 jwt claim formats (#88)
+- Logging and messaging improvements (#89)
 
 ## 1.2.2 - September 29, 2021
 

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -41,7 +41,7 @@ func TestInvalidToken(t *testing.T) {
 	}
 	client.SetToken(testToken)
 
-	assert.Equal(t, false, checkToken(client))
+	assert.Error(t, checkToken(client))
 }
 
 func TestValidToken(t *testing.T) {
@@ -56,7 +56,7 @@ func TestValidToken(t *testing.T) {
 	}
 	client.SetToken(testToken)
 
-	assert.Equal(t, true, checkToken(client))
+	assert.Equal(t, nil, checkToken(client))
 }
 
 func TestFileToken(t *testing.T) {
@@ -79,6 +79,6 @@ func TestFileToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, true, checkFileToken(client, file.Name()))
+	assert.Equal(t, nil, checkFileToken(client, file.Name()))
 	assert.Equal(t, testToken, client.Token())
 }

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -30,7 +30,7 @@ import (
 // CertFetcher is responsible for fetching certificates & keys..
 func CertFetcher(client *api.Client, config cfg.Config) {
 	if config.PkiCertificate == "" || config.PkiPrivateKey == "" {
-		log.Info().Msg("Certificate or private key output path is empty, will not attempt to get certificate")
+		log.Trace().Msg("Certificate or private key output path is empty, will not attempt to get certificate")
 		return
 	}
 	log.Info().Msg("Getting certificate from vault...")

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -30,7 +30,6 @@ import (
 // CertFetcher is responsible for fetching certificates & keys..
 func CertFetcher(client *api.Client, config cfg.Config) {
 	if config.PkiCertificate == "" || config.PkiPrivateKey == "" {
-		log.Trace().Msg("Certificate or private key output path is empty, will not attempt to get certificate")
 		return
 	}
 	log.Info().Msg("Getting certificate from vault...")


### PR DESCRIPTION
- Changed the signature of `checkToken` and `checkFileToken` to return `error` instead of `bool`, so that more detailed information can be relayed about the failure.
- Improved logging message clarity and intention
- Expose output errors that were previously not captured