### PR TITLE
Prevent inconsistencies when reading singular secrets paths that contain multiple keys 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.4 - Unreleased 
+
+- Handle data reading inconsistencies in singular definitions that have more than one data key (#91)
+
 ## 1.2.3 - July 14, 2022
 
 - Update to go 1.18.3 (#87)


### PR DESCRIPTION
Previously, when reading a singular secret definition and a singular output destination was specified, if more than one data key was returned, a data key value would be chosen at random, causing inconsistencies in the secret data being written. The new behavior defaults to always reading the default of `value` unless explicitly overwritten by `VAULT_VALUE_KEY_`.

The value `standard` is written to `/vault/secret-value`:
```
VAULT_SECRET_TEST=secret/path/testing
DAYTONA_SECRET_DESTINATION_TEST=/vault/secret-value

"data": {
    "value": "standard",
    "password": "nonstandard"
}
```

The value `nonstandard` is written to `/vault/secret-value`:
```
VAULT_SECRET_TEST=secret/path/testing
DAYTONA_SECRET_DESTINATION_TEST=/vault/secret-value
VAULT_VALUE_KEY_TEST=password

"data": {
    "value": "standard",
    "password": "nonstandard"
}
```