### PR TITLE
Add a longer retry wait to Vault client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.5 - Unreleased
+
+- Add a longer default Max Retry Wait to allow for 1 minute long rate limiting buckets
+
 ## 1.2.4 - October 24, 2022
 
 - Handle data reading inconsistencies in singular definitions that have more than one data key (#91)


### PR DESCRIPTION
The Vault API does not allow overriding the default max retry wait value via Environment variable. The default of 1500 milliseconds is sufficient if rate-limiting on 1 second buckets.

If using minute-length rate limiting buckets, we could need a longer value. This allows the Vault client to wait for a bit longer than a minute if the server instructs it to do so via the Retry-After header. It allows for overriding our new default via an environment variable if so desired.