### PR TITLE
Add support for no authentication scheme

### DIFF
--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -51,6 +51,7 @@ const (
 	flagK8SAuth    = "k8s-auth"
 	flagGCPAuth    = "gcp-auth"
 	flagAzureAuth  = "azure-auth"
+	flagNoAuth     = "no-auth"
 )
 
 func init() {
@@ -156,6 +157,10 @@ func init() {
 		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("AZURE_AUTH", "false"))
 		return err == nil && b
 	}(), "select Azure IAM auth as the vault authentication mechanism (env: AZURE_AUTH)")
+	flag.BoolVar(&config.NoAuth, flagNoAuth, func() bool {
+		b, err := strconv.ParseBool(cfg.BuildDefaultConfigItem("NO_AUTH", "false"))
+		return err == nil && b
+	}(), "disables authentication. Assumes that a valid vault token exists via the VAULT_TOKEN environment variable or in the TokenPath. No attempt will be made to authenticate if the Vault token is missing. (env: NO_AUTH)")
 }
 
 func main() {
@@ -164,7 +169,7 @@ func main() {
 	log.Info().Str("version", version).Msg("Starting...")
 
 	if !config.ValidateAuthType() {
-		log.Fatal().Strs("authFlags", []string{flagK8SAuth, flagAWSIAMAuth, flagGCPAuth}).Msg("You must provide an auth method. Exiting.")
+		log.Fatal().Strs("authFlags", []string{flagK8SAuth, flagAWSIAMAuth, flagGCPAuth, flagAzureAuth, flagNoAuth}).Msg("You must provide an auth method. Exiting.")
 	}
 
 	var mountPath string

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -94,6 +94,11 @@ func EnsureAuthenticated(client *api.Client, config cfg.Config) bool {
 	}
 	log.Info().Err(err).Str("tokenPath", config.TokenPath).Msg("File token failed, trying to re-authenticate")
 
+	if config.NoAuth {
+		log.Error().Msg("Authentication is disabled. No attempts will be made to authenticate.")
+		return false
+	}
+
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxInterval = time.Second * 15
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -96,6 +96,18 @@ func TestAuthPanic(t *testing.T) {
 	assert.Panics(t, func() { EnsureAuthenticated(client, config) }, "The code did not panic when it should have")
 }
 
+func TestNoAuth(t *testing.T) {
+	var config cfg.Config
+	config.NoAuth = true
+	client, err := testhelpers.GetTestClient("nan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SetToken(testToken)
+	config.MaximumAuthRetry = 1
+	assert.False(t, EnsureAuthenticated(client, config))
+}
+
 type MockedService struct {
 	mock.Mock
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Log               logging.Config
 	AzureAuth         bool
 	AzureAuthMount    string
+	NoAuth            bool
 }
 
 // BuildDefaultConfigItem uses the following operation: ENV --> arg
@@ -58,7 +59,7 @@ func BuildDefaultConfigItem(envKey string, def string) (val string) {
 // a valid authentication type
 func (c *Config) ValidateAuthType() bool {
 	p := 0
-	for _, v := range []bool{c.K8SAuth, c.AWSAuth, c.GCPAuth, c.AzureAuth} {
+	for _, v := range []bool{c.K8SAuth, c.AWSAuth, c.GCPAuth, c.AzureAuth, c.NoAuth} {
 		if v {
 			p++
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,3 +44,42 @@ func TestInvalidConfig(t *testing.T) {
 		t.Fatal("got an error in PKI config, didn't expect one, bailing")
 	}
 }
+
+func TestValidateAuthType(t *testing.T) {
+	t.Run("k8s_auth", func(t *testing.T) {
+		var config Config
+		config.K8SAuth = true
+		assert.True(t, config.ValidateAuthType())
+	})
+
+	t.Run("aws_auth", func(t *testing.T) {
+		var config Config
+		config.AWSAuth = true
+		assert.True(t, config.ValidateAuthType())
+	})
+
+	t.Run("azure_auth", func(t *testing.T) {
+		var config Config
+		config.AzureAuth = true
+		assert.True(t, config.ValidateAuthType())
+	})
+
+	t.Run("gcp_auth", func(t *testing.T) {
+		var config Config
+		config.GCPAuth = true
+		assert.True(t, config.ValidateAuthType())
+	})
+
+	t.Run("no_auth", func(t *testing.T) {
+		var config Config
+		config.NoAuth = true
+		assert.True(t, config.ValidateAuthType())
+	})
+
+	t.Run("multiple_auth_configured", func(t *testing.T) {
+		var config Config
+		config.K8SAuth = true
+		config.AWSAuth = true
+		assert.False(t, config.ValidateAuthType())
+	})
+}


### PR DESCRIPTION
Daytona currently does not perform authentication if a valid vault token exists as the environment variable `VAULT_TOKEN` or as a file in the specified `TokenPath` argument. To better support this behavior, I'm adding a "no auth" option in which authentication will be disabled. If a token cannot be found in the environment variable or file, Daytona will simply error out. 

This should make it easier to support cases where an existing token is used and no custom auth is desired. In our specific case, this enables us to avoid any risk of duplicate calls to Vault which can pose a scalability risk. 

Specific changes:
- support a `--no-auth` argument or `NO_AUTH` environment variable to indicate that no authentication scheme is desired
- (bug fix) report the Azure auth scheme as a valid option when logging the auth scheme required message
